### PR TITLE
Use inner Arc when cloning RedisPool

### DIFF
--- a/src/modules/pool.rs
+++ b/src/modules/pool.rs
@@ -18,9 +18,20 @@ pub(crate) struct RedisPoolInner {
 
 /// A struct to pool multiple Redis clients together into one interface that will round-robin requests among clients,
 /// preferring clients with an active connection if specified.
-#[derive(Clone)]
+///
+/// Cloning `RedisPool` is cheap as it only clones the pointer of the atomic reference-counted inner pool
+/// inside of the struct, this means that when you `Clone` you get a new reference of the same pool effectively
+/// keeping the same clients and connections.
 pub struct RedisPool {
   inner: Arc<RedisPoolInner>,
+}
+
+impl Clone for RedisPool {
+  fn clone(&self) -> Self {
+    Self {
+      inner: Arc::clone(&self.inner),
+    }
+  }
 }
 
 impl fmt::Display for RedisPool {


### PR DESCRIPTION
This makes the `RedisPool` cheaper to clone as it only clones the pointer of the Arc inside the struct instead of cloning the struct instance which means having two different pools.

The reasoning behind this change is that I think the default behavior when cloning a pool should be just cloning a reference to the inner instead of actually cloning the whole struct and ending up having two different instances of the same pool. If the user intended behavior is to have two different pools they should be using the `RedisPool::new()` function to create a new pool.

The approach I took it's similar to [what SQLx does](https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/pool/mod.rs#L521-L526) with a database `Pool`.

Feel free to suggest edits to the doc comment as English is not my primary language and there may be a more straightforward way of explaining it.

---

⚠️ **Disclaimer:** I skipped opening an issue and opened a PR directly as this is a simple change and I felt more comfortable explaining it in code rather than in text, I hope this is not a deal breaker for the contribution.