### PR TITLE
RedisKey::from(&str) constraint to 'static lifetimes

### DIFF
--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -279,9 +279,9 @@ impl From<Bytes> for RedisKey {
   }
 }
 
-impl<'a> From<&'a [u8]> for RedisKey {
-  fn from(b: &'a [u8]) -> Self {
-    RedisKey { key: b.to_vec().into() }
+impl From<&'static [u8]> for RedisKey {
+  fn from(b: &'static [u8]) -> Self {
+    Self::from_static(b)
   }
 }
 
@@ -300,11 +300,9 @@ impl From<String> for RedisKey {
   }
 }
 
-impl<'a> From<&'a str> for RedisKey {
-  fn from(s: &'a str) -> Self {
-    RedisKey {
-      key: s.as_bytes().to_vec().into(),
-    }
+impl From<&'static str> for RedisKey {
+  fn from(s: &'static str) -> Self {
+    Self::from_static_str(s)
   }
 }
 

--- a/tests/integration/geo/mod.rs
+++ b/tests/integration/geo/mod.rs
@@ -12,7 +12,7 @@ fn loose_eq_pos(lhs: &GeoPosition, rhs: &GeoPosition) -> bool {
   loose_eq(lhs.longitude, rhs.longitude, 5) && loose_eq(lhs.latitude, rhs.latitude, 5)
 }
 
-async fn create_fake_data(client: &RedisClient, key: &str) -> Result<Vec<GeoPosition>, RedisError> {
+async fn create_fake_data(client: &RedisClient, key: &'static str) -> Result<Vec<GeoPosition>, RedisError> {
   // GEOADD key 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
 
   let values = vec![

--- a/tests/integration/lists/mod.rs
+++ b/tests/integration/lists/mod.rs
@@ -6,7 +6,7 @@ use tokio::time::sleep;
 
 const COUNT: i64 = 10;
 
-async fn create_count_data(client: &RedisClient, key: &str) -> Result<Vec<RedisValue>, RedisError> {
+async fn create_count_data(client: &RedisClient, key: &'static str) -> Result<Vec<RedisValue>, RedisError> {
   let mut values = Vec::with_capacity(COUNT as usize);
   for idx in 0..COUNT {
     let _: () = client.rpush(key, idx).await?;

--- a/tests/integration/sorted_sets/mod.rs
+++ b/tests/integration/sorted_sets/mod.rs
@@ -18,7 +18,7 @@ fn f64_cmp(lhs: f64, rhs: f64) -> CmpOrdering {
   }
 }
 
-async fn create_lex_data(client: &RedisClient, key: &str) -> Result<Vec<(f64, RedisValue)>, RedisError> {
+async fn create_lex_data(client: &RedisClient, key: &'static str) -> Result<Vec<(f64, RedisValue)>, RedisError> {
   let values: Vec<(f64, String)> = "abcdefghijklmnopqrstuvwxyz"
     .chars()
     .map(|c| (0.0, c.to_string()))
@@ -28,7 +28,7 @@ async fn create_lex_data(client: &RedisClient, key: &str) -> Result<Vec<(f64, Re
   Ok(values.into_iter().map(|(f, v)| (f, v.into())).collect())
 }
 
-async fn create_count_data(client: &RedisClient, key: &str) -> Result<Vec<(f64, RedisValue)>, RedisError> {
+async fn create_count_data(client: &RedisClient, key: &'static str) -> Result<Vec<(f64, RedisValue)>, RedisError> {
   let values: Vec<(f64, RedisValue)> = (0..COUNT)
     .into_iter()
     .map(|idx| (idx as f64, idx.to_string().into()))

--- a/tests/integration/streams/mod.rs
+++ b/tests/integration/streams/mod.rs
@@ -7,13 +7,13 @@ use tokio::time::sleep;
 
 type FakeExpectedValues = Vec<HashMap<String, HashMap<String, usize>>>;
 
-async fn create_fake_group_and_stream(client: &RedisClient, key: &str) -> Result<(), RedisError> {
+async fn create_fake_group_and_stream(client: &RedisClient, key: &'static str) -> Result<(), RedisError> {
   client.xgroup_create(key, "group1", "$", true).await
 }
 
 async fn add_stream_entries(
   client: &RedisClient,
-  key: &str,
+  key: &'static str,
   count: usize,
 ) -> Result<(Vec<String>, FakeExpectedValues), RedisError> {
   let mut ids = Vec::with_capacity(count);


### PR DESCRIPTION
Typically, when callers pass a key of type `&str`, it most of the time from a `&'static str`. This pull request takes this into account and avoid an allocation.

If the caller has constructed a string, for example with `format!("users/{}", user.id)`, then we'll take this as a `String`, and there's no allocation needed.

If the caller constructs a string, but wants to reuse it, the caller will have to invoke `.clone()` on the string.