### PR TITLE
Ensure client is authenticated before switching to RESP3

### DIFF
--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -332,8 +332,9 @@ pub async fn create_authenticated_connection_tls(
   let socket = TcpStream::connect(addr).await?;
   let tls_stream = tls::create_tls_connector(&inner.config)?;
   let socket = tls_stream.connect(domain, socket).await?;
-  let framed = switch_protocols(inner, Framed::new(socket, codec)).await?;
+  let framed = Framed::new(socket, codec);
   let framed = authenticate(framed, &client_name, username, password, inner.is_resp3()).await?;
+  let framed = switch_protocols(inner, framed).await?;
   let framed = select_database(inner, framed).await?;
 
   client_utils::set_client_state(&inner.state, ClientState::Connected);
@@ -360,8 +361,9 @@ pub async fn create_authenticated_connection(
   let username = inner.config.read().username.clone();
 
   let socket = TcpStream::connect(addr).await?;
-  let framed = switch_protocols(inner, Framed::new(socket, codec)).await?;
+  let framed = Framed::new(socket, codec);
   let framed = authenticate(framed, &client_name, username, password, inner.is_resp3()).await?;
+  let framed = switch_protocols(inner, framed).await?;
   let framed = select_database(inner, framed).await?;
 
   client_utils::set_client_state(&inner.state, ClientState::Connected);


### PR DESCRIPTION
If not done so, the following error will happen (if password is
required):

```
NOAUTH HELLO must be called with the client already authenticated,
otherwise the HELLO AUTH <user> <pass> option can be used to
authenticate the client and select the RESP protocol version at the same
time
```

Closes #54 