### PR TITLE
Send [p|un|]subscribe commands to all nodes in the cluster

### DIFF
--- a/src/multiplexer/mod.rs
+++ b/src/multiplexer/mod.rs
@@ -523,7 +523,7 @@ impl Multiplexer {
       self.inner.counters.incr_redelivery_count();
     }
 
-    if command.kind.is_all_cluster_nodes() {
+    if command.kind.is_all_cluster_nodes() || command.is_all_cluster_nodes() {
       self.connections.write_all_cluster(&self.inner, command).await
     } else {
       match self.connections.write_command(&self.inner, command).await {

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -1673,6 +1673,24 @@ impl RedisCommand {
       protocol_utils::command_to_frame(self, is_resp3)
     }
   }
+
+  // Check if command arguments justify sending it to all cluster nodes
+  pub fn is_all_cluster_nodes(&self) -> bool {
+    match self.kind {
+      RedisCommandKind::Psubscribe
+      | RedisCommandKind::Subscribe
+      | RedisCommandKind::Unsubscribe => {
+        if let Some(key) = self.first_key() {
+          key.starts_with(b"__keyspace@") ||
+          key.starts_with(b"__keyevent@")
+        } else {
+          false
+        }
+
+      },
+      _ => false,
+    }
+  }
 }
 
 /// A message sent from the front-end client to the multiplexer.

--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -1680,6 +1680,7 @@ impl RedisCommand {
       RedisCommandKind::Psubscribe
       | RedisCommandKind::Subscribe
       | RedisCommandKind::Unsubscribe => {
+        // TODO: Handle multiple channels/patterns
         if let Some(key) = self.first_key() {
           key.starts_with(b"__keyspace@") ||
           key.starts_with(b"__keyevent@")


### PR DESCRIPTION
 if they are subscribing to the keyspace notifications, because these notifications are neither sharded nor global. 