### PR TITLE
test: repro panic for tracing

### DIFF
--- a/bin/pipeline_test/src/main.rs
+++ b/bin/pipeline_test/src/main.rs
@@ -222,9 +222,10 @@ fn main() {
     let perf = PerformanceConfig {
       auto_pipeline: argv.pipeline,
       default_command_timeout_ms: 5000,
+      max_command_attempts: 0,
       backpressure: BackpressureConfig {
         policy: BackpressurePolicy::Drain,
-        max_in_flight_commands: 100_000_000,
+        max_in_flight_commands: 100,
         ..Default::default()
       },
       ..Default::default()


### PR DESCRIPTION
I was able to repro panic for #73 again with high-concurrency. Command to run was:
`cargo run --features stdout-tracing  -- --cluster --port 8000 ---count 1000000 --pool 5 --tracing --concurrency 100000 pipeline`

It doesn't require any actions with redis itself (restart/failvor isn't needed) and looks related to back-pressure logic