### PR TITLE
feat(tracing): allow to configure span levels

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,6 +7,8 @@ use std::{default::Default, sync::Arc};
 
 #[cfg(feature = "mocks")]
 use fred::mocks::Echo;
+#[cfg(feature = "partial-tracing")]
+use fred::types::TracingConfig;
 
 const DATABASE: u8 = 2;
 
@@ -39,7 +41,7 @@ async fn main() -> Result<(), RedisError> {
     tls: None,
     // Whether or not to enable tracing for this client.
     #[cfg(feature = "partial-tracing")]
-    tracing: false,
+    tracing: TracingConfig::enabled(false),
     // An optional mocking layer to intercept and process commands.
     #[cfg(feature = "mocks")]
     mocks: Arc::new(Echo),
@@ -65,6 +67,7 @@ async fn main() -> Result<(), RedisError> {
       // the policy to apply when the max in-flight commands count is reached
       policy:                    BackpressurePolicy::Drain,
     },
+    network_timeout_ms: 0,
   };
 
   // configure exponential backoff when reconnecting, starting at 100 ms, and doubling each time up to 30 sec.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -49,11 +49,23 @@ macro_rules! _info(
 /// Span used within the client that uses the command's span ID as the parent.
 #[cfg(any(feature = "full-tracing", feature = "partial-tracing"))]
 macro_rules! fspan (
-  ($cmd:ident, $($arg:tt)*) => { {
+  ($cmd:ident, $lvl:expr, $($arg:tt)*) => { {
     let _id = $cmd.traces.cmd.as_ref().and_then(|c| c.id());
-    tracing::span!(parent: _id, tracing::Level::INFO, $($arg)*)
+    span_lvl!($lvl, parent: _id, $($arg)*)
   } }
 );
+
+macro_rules! span_lvl {
+    ($lvl:expr, $($args:tt)*) => {{
+        match $lvl {
+            tracing::Level::ERROR => tracing::error_span!($($args)*),
+            tracing::Level::WARN => tracing::warn_span!($($args)*),
+            tracing::Level::INFO => tracing::info_span!($($args)*),
+            tracing::Level::DEBUG => tracing::debug_span!($($args)*),
+            tracing::Level::TRACE => tracing::trace_span!($($args)*),
+        }
+    }};
+}
 
 /// Fake span used within the client that uses the command's span ID as the parent.
 #[cfg(not(any(feature = "full-tracing", feature = "partial-tracing")))]

--- a/src/modules/inner.rs
+++ b/src/modules/inner.rs
@@ -538,7 +538,17 @@ impl RedisClientInner {
 
   #[cfg(feature = "partial-tracing")]
   pub fn should_trace(&self) -> bool {
-    self.config.tracing
+    self.config.tracing.enable
+  }
+
+  #[cfg(feature = "partial-tracing")]
+  pub fn tracing_span_level(&self) -> tracing::Level {
+    self.config.tracing.spans_level
+  }
+
+  #[cfg(feature = "full-tracing")]
+  pub fn full_tracing_span_level(&self) -> tracing::Level {
+    self.config.tracing.full_spans_level
   }
 
   #[cfg(not(feature = "partial-tracing"))]

--- a/src/multiplexer/commands.rs
+++ b/src/multiplexer/commands.rs
@@ -205,7 +205,7 @@ async fn write_with_backpressure_t(
 ) -> Result<(), RedisError> {
   if inner.should_trace() {
     command.take_queued_span();
-    let span = fspan!(command, "process_command");
+    let span = fspan!(command, inner.full_tracing_span_level(), "process_command");
     write_with_backpressure(inner, multiplexer, command, force_pipeline)
       .instrument(span)
       .await

--- a/src/multiplexer/responses.rs
+++ b/src/multiplexer/responses.rs
@@ -113,12 +113,7 @@ pub fn check_pubsub_message(inner: &Arc<RedisClientInner>, frame: Resp3Frame) ->
     return Some(frame);
   }
 
-  let span = if inner.should_trace() {
-    let span = trace::create_pubsub_span(inner, &frame);
-    Some(span)
-  } else {
-    None
-  };
+  let span = trace::create_pubsub_span(inner, &frame);
 
   _trace!(inner, "Processing pubsub message.");
   let parsed_frame = if let Some(ref span) = span {

--- a/src/trace/README.md
+++ b/src/trace/README.md
@@ -11,16 +11,16 @@ See the [pipeline test](../../bin/pipeline_test) test application for an example
 
 This table shows the spans emitted by the client. The `Partial Trace` column describes whether the span will show up when only the `partial-tracing` feature flag is enabled.
 
-|   Name                  | Description                                                                                                                                             | Partial Trace |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| redis_command           | The top level span used for all redis commands.                                                                                                         |      x        |
-| prepare_args            | Time spent checking and preparing arguments.                                                                                                            |               |
-| queued                  | Time spent waiting in the in-memory queue before being sent to the server. Pipelining and backpressure settings can drastically affect this.            |               |
-| handle_command          | Time spent checking, encoding, and writing the command to the socket.                                                                                   |               |
-| check_command_structure | Time spent checking the command structure for correctness in the context of the client's current state.                                                 |               |
-| write_to_socket         | Time spent encoding and feeding bytes to the socket.                                                                                                    |               |
-| wait_for_response       | Time spent waiting on a response from the server, starting from when the first byte is fed to the socket and ending when the response has been decoded. |      x        |
-| parse_pubsub            | Time spent parsing a publish-subscribe message.                                                                                                         |               |
+| Name              | Description                                                                                                                                             | Partial Trace |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| redis_command     | The top level span used for all redis commands.                                                                                                         | x             |
+| prepare_args      | Time spent checking and preparing arguments.                                                                                                            |               |
+| queued            | Time spent waiting in the in-memory queue before being sent to the server. Pipelining and backpressure settings can drastically affect this.            |               |
+| parse_pubsub      | Time spent parsing a publish-subscribe message.                                                                                                         |               |
+| process_command   | Time spent for processing a command.                                                                                                                    |               |
+| wait_for_response | Time spent waiting on a response from the server, starting from when the first byte is fed to the socket and ending when the response has been decoded. | x             |
+
+Level of spans can be configured through [TracingConfig](../types/config.rs)
 
 ## Events
 

--- a/src/trace/disabled.rs
+++ b/src/trace/disabled.rs
@@ -25,11 +25,11 @@ impl Span {
 }
 
 #[cfg(not(any(feature = "full-tracing", feature = "partial-tracing")))]
-pub fn set_network_span(_command: &mut RedisCommand, _flush: bool) {}
+pub fn set_network_span(_inner: &Arc<RedisClientInner>, _command: &mut RedisCommand, _flush: bool) {}
 
 #[cfg(not(any(feature = "full-tracing", feature = "partial-tracing")))]
-pub fn create_pubsub_span(_inner: &Arc<RedisClientInner>, _frame: &Frame) -> Span {
-  Span {}
+pub fn create_pubsub_span(_inner: &Arc<RedisClientInner>, _frame: &Frame) -> Option<Span> {
+  Some(Span {})
 }
 
 #[cfg(not(any(feature = "full-tracing", feature = "partial-tracing")))]

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("./README.md")]
+
 pub mod disabled;
 #[cfg(any(feature = "full-tracing", feature = "partial-tracing"))]
 mod enabled;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -1,5 +1,3 @@
-#![doc = include_str!("./README.md")]
-
 pub mod disabled;
 #[cfg(any(feature = "full-tracing", feature = "partial-tracing"))]
 mod enabled;

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -411,12 +411,10 @@ pub struct RedisConfig {
   #[cfg(any(feature = "enable-native-tls", feature = "enable-rustls"))]
   #[cfg_attr(docsrs, doc(cfg(any(feature = "enable-native-tls", feature = "enable-rustls"))))]
   pub tls:       Option<TlsConfig>,
-  /// Whether or not to enable tracing for this client.
-  ///
-  /// Default: `false`
+  /// Configuration of tracing for this client.
   #[cfg(feature = "partial-tracing")]
   #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
-  pub tracing:   bool,
+  pub tracing:   TracingConfig,
   /// An optional [mocking layer](crate::mocks) to intercept and process commands.
   ///
   /// Default: [Echo](crate::mocks::Echo)
@@ -452,7 +450,7 @@ impl Default for RedisConfig {
       #[cfg(any(feature = "enable-native-tls", feature = "enable-rustls"))]
       tls: None,
       #[cfg(feature = "partial-tracing")]
-      tracing: false,
+      tracing: TracingConfig::default(),
       #[cfg(feature = "mocks")]
       mocks: Arc::new(Echo),
     }
@@ -841,6 +839,59 @@ impl ServerConfig {
       ServerConfig::Centralized { ref host, port } => vec![(host.as_str(), port)],
       ServerConfig::Clustered { ref hosts } => hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect(),
       ServerConfig::Sentinel { ref hosts, .. } => hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect(),
+    }
+  }
+}
+
+/// Configuration options for tracing.
+#[cfg(feature = "partial-tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
+#[derive(Clone, Debug)]
+pub struct TracingConfig {
+  /// Whether or not to enable tracing for this client.
+  ///
+  /// Default: `false`
+  #[cfg(feature = "partial-tracing")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
+  pub enable:   bool,
+
+  /// Set `tracing::Level` of `spans` under `partial-tracing` feature
+  /// See [trace documentation](crate::trace) to check included spans
+  ///
+  /// Default: `tracing::Level::INFO`
+  #[cfg(feature = "partial-tracing")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
+  pub spans_level: tracing::Level,
+
+  /// Set `tracing::Level` of `spans` under `full-tracing` feature
+  /// See [trace documentation](crate::trace)  to check included spans
+  ///
+  /// Default: `tracing::Level::DEBUG`
+  #[cfg(feature = "full-tracing")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "full-tracing")))]
+  pub full_spans_level: tracing::Level,
+}
+
+#[cfg(feature = "partial-tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
+impl TracingConfig {
+  pub fn enabled(enable: bool) -> Self {
+    Self {
+      enable,
+      ..Self::default()
+    }
+  }
+}
+
+#[cfg(feature = "partial-tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
+impl Default for TracingConfig {
+  fn default() -> Self {
+    Self {
+      enable: false,
+      spans_level: tracing::Level::INFO,
+      #[cfg(feature = "full-tracing")]
+      full_spans_level: tracing::Level::DEBUG,
     }
   }
 }

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -844,6 +844,7 @@ impl ServerConfig {
 }
 
 /// Configuration options for tracing.
+#[doc = include_str!("../trace/README.md")]
 #[cfg(feature = "partial-tracing")]
 #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
 #[derive(Clone, Debug)]
@@ -855,16 +856,14 @@ pub struct TracingConfig {
   #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
   pub enable:   bool,
 
-  /// Set `tracing::Level` of `spans` under `partial-tracing` feature
-  /// See [trace documentation](crate::trace) to check included spans
+  /// Set `tracing::Level` of `spans` under `partial-tracing` feature (see config-level documentation)
   ///
   /// Default: `tracing::Level::INFO`
   #[cfg(feature = "partial-tracing")]
   #[cfg_attr(docsrs, doc(cfg(feature = "partial-tracing")))]
   pub spans_level: tracing::Level,
 
-  /// Set `tracing::Level` of `spans` under `full-tracing` feature
-  /// See [trace documentation](crate::trace)  to check included spans
+  /// Set `tracing::Level` of `spans` under `full-tracing` feature (see config-level documentation)
   ///
   /// Default: `tracing::Level::DEBUG`
   #[cfg(feature = "full-tracing")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -447,7 +447,7 @@ where
   let end_cmd_span = cmd_span.clone();
 
   let (mut command, rx, req_size) = {
-    let args_span = trace::create_args_span(cmd_span.id());
+    let args_span = trace::create_args_span(cmd_span.id(), inner);
     let _enter = args_span.enter();
     let (tx, rx) = oneshot_channel();
 


### PR DESCRIPTION
I'd like to be able to configure level of spans created by `fred` (like `sqlx` does for example). 

However I'm not sure how to better to do that, as I understood, currently `DEBUG` is used for `full-tracing` spans and `INFO` for `partial-tracing` ones.
So I made two separate config options under the feature, don't think it makes much sense to be able to configure each span separately.  Or probably it make sense to keep them with one level independently of feature 🤔 

Please, take a look, any comments and improvements are welcome!