### PR TITLE
rename, renamenx and unlink

### DIFF
--- a/bin/inf_loop/run.sh
+++ b/bin/inf_loop/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 TEST_ARGV="$@" docker-compose -f ../../tests/docker/compose/cluster.yml -f ../../tests/docker/compose/centralized.yml -f ./docker-compose.yml \
-  run -T -u $(id -u ${USER}):$(id -g ${USER}) --rm inf-loop
+  run -u $(id -u ${USER}):$(id -g ${USER}) --rm inf-loop

--- a/bin/inf_loop/src/main.rs
+++ b/bin/inf_loop/src/main.rs
@@ -87,6 +87,7 @@ async fn main() -> Result<(), RedisError> {
   };
   let perf = PerformanceConfig {
     auto_pipeline: true,
+    max_command_attempts: 1,
     network_timeout_ms: 5_000,
     default_command_timeout_ms: 300_000,
     ..Default::default()

--- a/src/commands/impls/keys.rs
+++ b/src/commands/impls/keys.rs
@@ -55,6 +55,14 @@ pub async fn del<C: ClientLike>(client: &C, keys: MultipleKeys) -> Result<RedisV
   protocol_utils::frame_to_results(frame)
 }
 
+pub async fn unlink<C: ClientLike>(client: &C, keys: MultipleKeys) -> Result<RedisValue, RedisError> {
+  utils::check_empty_keys(&keys)?;
+
+  let args: Vec<RedisValue> = keys.inner().drain(..).map(|k| k.into()).collect();
+  let frame = utils::request_response(client, move || Ok((RedisCommandKind::Unlink, args))).await?;
+  protocol_utils::frame_to_results(frame)
+}
+
 pub async fn append<C: ClientLike>(client: &C, key: RedisKey, value: RedisValue) -> Result<RedisValue, RedisError> {
   args_value_cmd(client, RedisCommandKind::Append, vec![key.into(), value]).await
 }
@@ -218,6 +226,14 @@ pub async fn setrange<C: ClientLike>(
 
 pub async fn getset<C: ClientLike>(client: &C, key: RedisKey, value: RedisValue) -> Result<RedisValue, RedisError> {
   args_values_cmd(client, RedisCommandKind::GetSet, vec![key.into(), value]).await
+}
+
+pub async fn rename<C: ClientLike>(client: &C, source: RedisKey, destination: RedisKey) -> Result<RedisValue, RedisError> {
+  args_values_cmd(client, RedisCommandKind::Rename, vec![source.into(), destination.into()]).await
+}
+
+pub async fn renamenx<C: ClientLike>(client: &C, source: RedisKey, destination: RedisKey) -> Result<RedisValue, RedisError> {
+  args_values_cmd(client, RedisCommandKind::Renamenx, vec![source.into(), destination.into()]).await
 }
 
 pub async fn getdel<C: ClientLike>(client: &C, key: RedisKey) -> Result<RedisValue, RedisError> {

--- a/src/commands/interfaces/keys.rs
+++ b/src/commands/interfaces/keys.rs
@@ -207,6 +207,52 @@ pub trait KeysInterface: ClientLike + Sized {
     commands::keys::del(self, keys).await?.convert()
   }
 
+  /// Unlinks the specified keys. A key is ignored if it does not exist
+  ///
+  /// Returns the number of keys removed.
+  ///
+  /// <https://redis.io/commands/del>
+  async fn unlink<R, K>(&self, keys: K) -> RedisResult<R>
+  where
+    R: FromRedis,
+    K: Into<MultipleKeys> + Send,
+  {
+    into!(keys);
+    commands::keys::unlink(self, keys).await?.convert()
+  }
+
+  /// Renames `source` key to `destination`.
+  ///
+  /// Returns an error when `source` does not exist. If `destination` exists, it gets overwritten.
+  ///
+  /// <https://redis.io/commands/rename>
+  async fn rename<R, S, D>(&self, source: S, destination: D) -> RedisResult<R>
+  where
+    R: FromRedis,
+    S: Into<RedisKey> + Send,
+    D: Into<RedisKey> + Send,
+  {
+    into!(source);
+    into!(destination);
+    commands::keys::rename(self, source, destination).await?.convert()
+  }
+
+  /// Renames `source` key to `destination` if `destination` does not yet exist.
+  ///
+  /// Returns an error when `source` does not exist.
+  ///
+  /// <https://redis.io/commands/renamenx>
+  async fn renamenx<R, S, D>(&self, source: S, destination: D) -> RedisResult<R>
+  where
+    R: FromRedis,
+    S: Into<RedisKey> + Send,
+    D: Into<RedisKey> + Send,
+  {
+    into!(source);
+    into!(destination);
+    commands::keys::renamenx(self, source, destination).await?.convert()
+  }
+
   /// Append `value` to `key` if it's a string.
   ///
   /// <https://redis.io/commands/append/>

--- a/src/router/responses.rs
+++ b/src/router/responses.rs
@@ -18,13 +18,13 @@ const KEYEVENT_PREFIX: &'static str = "__keyevent@";
 
 fn parse_keyspace_notification(channel: &str, message: &RedisValue) -> Option<KeyspaceEvent> {
   if channel.starts_with(KEYEVENT_PREFIX) {
-    let parts: Vec<&str> = channel.split("@").collect();
-    if parts.len() != 2 {
+    let parts: Vec<&str> = channel.splitn(2, "@").collect();
+    if parts.len() < 2 {
       return None;
     }
 
-    let suffix: Vec<&str> = parts[1].split(":").collect();
-    if suffix.len() != 2 {
+    let suffix: Vec<&str> = parts[1].splitn(2, ":").collect();
+    if suffix.len() < 2 {
       return None;
     }
 
@@ -40,13 +40,13 @@ fn parse_keyspace_notification(channel: &str, message: &RedisValue) -> Option<Ke
 
     Some(KeyspaceEvent { db, key, operation })
   } else if channel.starts_with(KEYSPACE_PREFIX) {
-    let parts: Vec<&str> = channel.split("@").collect();
-    if parts.len() != 2 {
+    let parts: Vec<&str> = channel.splitn(2, "@").collect();
+    if parts.len() < 2 {
       return None;
     }
 
-    let suffix: Vec<&str> = parts[1].split(":").collect();
-    if suffix.len() != 2 {
+    let suffix: Vec<&str> = parts[1].splitn(2, ":").collect();
+    if suffix.len() < 2 {
       return None;
     }
 

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -20,6 +20,11 @@ mod keys {
   centralized_test!(keys, should_mget_values);
   centralized_test!(keys, should_msetnx_values);
   centralized_test!(keys, should_copy_values);
+  centralized_test!(keys, should_unlink);
+  centralized_test_panic!(keys, should_error_rename_does_not_exist);
+  centralized_test_panic!(keys, should_error_renamenx_does_not_exist);
+  centralized_test!(keys, should_rename);
+  centralized_test!(keys, should_renamenx);
 
   #[cfg(not(feature = "chaos-monkey"))]
   centralized_test!(keys, should_get_keys_from_pool_in_a_stream);

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -169,6 +169,7 @@ pub mod lua {
   centralized_test!(lua, should_eval_echo_script);
   centralized_test!(lua, should_eval_get_script);
   centralized_test!(lua, should_evalsha_echo_script);
+  centralized_test!(lua, should_evalsha_with_reload_echo_script);
   centralized_test!(lua, should_evalsha_get_script);
 
   centralized_test!(lua, should_function_load_scripts);

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -170,6 +170,7 @@ pub mod lua {
   cluster_test!(lua, should_eval_echo_script);
   cluster_test!(lua, should_eval_get_script);
   cluster_test!(lua, should_evalsha_echo_script);
+  cluster_test!(lua, should_evalsha_with_reload_echo_script);
   cluster_test!(lua, should_evalsha_get_script);
 
   cluster_test!(lua, should_function_load_scripts);

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -20,6 +20,11 @@ mod keys {
   cluster_test!(keys, should_mget_values);
   cluster_test!(keys, should_msetnx_values);
   cluster_test!(keys, should_copy_values);
+  cluster_test!(keys, should_unlink);
+  cluster_test_panic!(keys, should_error_rename_does_not_exist);
+  cluster_test_panic!(keys, should_error_renamenx_does_not_exist);
+  cluster_test!(keys, should_rename);
+  cluster_test!(keys, should_renamenx);
 
   #[cfg(not(feature = "chaos-monkey"))]
   cluster_test!(keys, should_get_keys_from_pool_in_a_stream);

--- a/tests/integration/keys/mod.rs
+++ b/tests/integration/keys/mod.rs
@@ -45,6 +45,56 @@ pub async fn should_set_with_get_argument(client: RedisClient, _config: RedisCon
   Ok(())
 }
 
+pub async fn should_rename(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
+  check_null!(client, "{foo}.1");
+  check_null!(client, "{foo}.2");
+
+  let _: () = client.set("{foo}.1", "baz", None, None, false).await?;
+
+  let _: () = client.rename("{foo}.1", "{foo}.2").await?;
+  let result: String = client.get("{foo}.2").await?;
+  assert_eq!(result, "baz");
+  check_null!(client, "{foo}.1");
+
+  Ok(())
+}
+
+pub async fn should_error_rename_does_not_exist(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
+  check_null!(client, "{foo}");
+  client.rename("{foo}", "{foo}.bar").await
+}
+
+pub async fn should_renamenx(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
+  check_null!(client, "{foo}.1");
+  check_null!(client, "{foo}.2");
+
+  let _: () = client.set("{foo}.1", "baz", None, None, false).await?;
+
+  let _: () = client.renamenx("{foo}.1", "{foo}.2").await?;
+  let result: String = client.get("{foo}.2").await?;
+  assert_eq!(result, "baz");
+  check_null!(client, "{foo}.1");
+
+  Ok(())
+}
+
+pub async fn should_error_renamenx_does_not_exist(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
+  check_null!(client, "{foo}");
+  client.renamenx("{foo}", "{foo}.bar").await
+}
+
+pub async fn should_unlink(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
+  check_null!(client, "{foo}1");
+
+  let _: () = client.set("{foo}1", "bar", None, None, false).await?;
+
+  assert_eq!(client.get::<String, _>("{foo}1").await?, "bar");
+  assert_eq!(client.unlink::<i64, _>(vec!["{foo}1", "{foo}", "{foo}:something"]).await?, 1);
+  check_null!(client, "{foo}1");
+
+  Ok(())
+}
+
 pub async fn should_incr_and_decr_a_value(client: RedisClient, _config: RedisConfig) -> Result<(), RedisError> {
   check_null!(client, "foo");
 

--- a/tests/integration/lua/mod.rs
+++ b/tests/integration/lua/mod.rs
@@ -54,6 +54,18 @@ pub async fn should_evalsha_echo_script(client: RedisClient, _: RedisConfig) -> 
   Ok(())
 }
 
+pub async fn should_evalsha_with_reload_echo_script(client: RedisClient, _: RedisConfig) -> Result<(), RedisError> {
+  let script = Script::from_lua(ECHO_SCRIPT);
+
+  let result: Vec<String> = script
+    .evalsha_with_reload(&client, vec!["a{1}", "b{1}"], vec!["c{1}", "d{1}"])
+    .await?;
+  assert_eq!(result, vec!["a{1}", "b{1}", "c{1}", "d{1}"]);
+
+  let _ = flush_scripts(&client).await?;
+  Ok(())
+}
+
 pub async fn should_evalsha_get_script(client: RedisClient, _: RedisConfig) -> Result<(), RedisError> {
   let script_hash = util::sha1_hash(GET_SCRIPT);
   let hash = load_script(&client, GET_SCRIPT).await?;

--- a/tests/runners/everything.sh
+++ b/tests/runners/everything.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-tests/runners/no-features.sh \
-  && tests/runners/default-features.sh \
-  && tests/runners/all-features.sh \
-  && tests/runners/sentinel-features.sh \
-  && tests/runners/cluster-native-tls.sh \
-  && tests/runners/cluster-rustls.sh
+tests/runners/no-features.sh "$1"\
+  && tests/runners/default-features.sh "$1"\
+  && tests/runners/all-features.sh "$1"\
+  && tests/runners/sentinel-features.sh "$1"\
+  && tests/runners/cluster-native-tls.sh "$1"\
+  && tests/runners/cluster-rustls.sh "$1"


### PR DESCRIPTION
Adds the three functions that were not exposed.

In particular the `renamenx` and `unlink` are very convenient for "quick delete" actions (by renaming to `{previous_key}:some_random_value` and then unlinking that)