### PR TITLE
Bump tokio-rustls to 0.24 to ensure dependency convergence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ tracing = { version = "0.1", optional = true }
 tracing-futures = { version = "0.2", optional = true }
 nom = { version = "7.1", optional = true }
 serde_json = { version = "1", optional = true }
-tokio-rustls = { version = "0.23", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
+webpki = { package = "rustls-webpki", version = "0.100", features = ["alloc", "std"], optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 trust-dns-resolver = { version =  "0.22", optional = true }
 
@@ -107,7 +108,7 @@ metrics = []
 mocks = []
 dns = ["trust-dns-resolver", "trust-dns-resolver/tokio"]
 ignore-auth-error = []
-enable-rustls = ["rustls", "tokio-rustls", "rustls-native-certs"]
+enable-rustls = ["rustls", "tokio-rustls", "rustls-native-certs", "webpki"]
 enable-native-tls = ["native-tls", "tokio-native-tls"]
 vendored-openssl = ["enable-native-tls", "native-tls/vendored"]
 reconnect-on-auth-error = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -295,8 +295,8 @@ impl From<tokio_rustls::rustls::client::InvalidDnsNameError> for RedisError {
 #[doc(hidden)]
 #[cfg(feature = "enable-rustls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "enable-rustls")))]
-impl From<tokio_rustls::webpki::Error> for RedisError {
-  fn from(e: tokio_rustls::webpki::Error) -> Self {
+impl From<webpki::Error> for RedisError {
+  fn from(e: webpki::Error) -> Self {
     RedisError::new(RedisErrorKind::Tls, format!("{:?}", e))
   }
 }


### PR DESCRIPTION
`tokio-rustls 0.23` depends on `rustls = 0.20`, which conflicts with `rustls = 0.21` requirement.

This change bumps the `tokio-rustls` to 0.24. `tokio-rustls` no longer re-exports `webpki`, so this change adds `webpki` as a dependency as well.