### PR TITLE
docs: fix `TracingConfig` not included in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ features = [
   "dns",
   "enable-rustls",
   "enable-native-tls",
+  "full-tracing",
+  "partial-tracing",
   "blocking-encoding",
   "custom-reconnect-errors",
   "monitor",


### PR DESCRIPTION
This PR fixes `TracingConfig` and other tracing related types not included in the docs.