### PR TITLE
Fix the recovery issue in kubernetes

### DIFF
--- a/src/router/clustered.rs
+++ b/src/router/clustered.rs
@@ -593,6 +593,7 @@ pub async fn cluster_slots_backchannel(
   };
   _trace!(inner, "Recv CLUSTER SLOTS response: {:?}", response);
   if response.is_null() {
+    inner.backchannel.write().await.check_and_disconnect(inner, None).await;
     return Err(RedisError::new(
       RedisErrorKind::Protocol,
       "Invalid or missing CLUSTER SLOTS response.",


### PR DESCRIPTION
The fred.rs sometimes can't recovery when connecting to a redis cluster inside kubernetes. This issue could be reproduced using following command in k8s:

kubectl scale statefuleset redis --replicas 0
kubectl scale statefuleset redis --replicas 8

When redis cluster recovered, fred.rs sometimes will failed to connect. I've implement the DNS interface. Through the logs, it seems fred.rs still connects to old IPs of the redis pods and tries to get the redis cluster nodes but got NULL.

The fix of this issue is to release the backchannel if the result is null, in this case, fred.rs will use the configured redis URL, (in our case it is the FQDN of the k8s service), and do DNS query. The result of the query will be one of the new IPs of the new redis Pod. And then fred.rs could establish a new connection to the new IP to get the up-to-date cluster nodes.

I've implement this change in our testing tools, and I've tested it with traffic for a long time. It always recovers now.