### PR TITLE
6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 6.2.2
+## 6.3.0
 
 * Fix cluster replica discovery with Elasticache
 * Fix cluster replica `READONLY` usage
+* Fix compilation error with `full-tracing`
+* Support `Vec<(T1, T2, ...)>` with `FromRedis`
 
 ## 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 6.2.2
+
+* Fix cluster replica discovery with Elasticache
+* Fix cluster replica `READONLY` usage
+
 ## 6.2.1
 
-* Fix cluster failover with paused nodes. 
+* Fix cluster failover with paused nodes
 
 ## 6.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "6.2.1"
+version = "6.2.2"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2021"
 description = "An async Redis client built on Tokio."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "6.2.2"
+version = "6.3.0"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2021"
 description = "An async Redis client built on Tokio."

--- a/src/clients/redis.rs
+++ b/src/clients/redis.rs
@@ -242,53 +242,12 @@ impl RedisClient {
     Pipeline::from(self.clone())
   }
 
-  /// Send subsequent commands to the provided cluster node.
+  /// Send commands to the provided cluster node.
   ///
   /// The caller will receive a `RedisErrorKind::Cluster` error if the provided server does not exist.
   ///
   /// The client will still automatically follow `MOVED` errors via this interface. Callers may not notice this, but
   /// incorrect server arguments here could result in unnecessary calls to refresh the cached cluster routing table.
-  ///
-  /// ```
-  /// # use fred::prelude::*;
-  ///
-  /// async fn example(client: &RedisClient) -> Result<(), RedisError> {
-  ///   // discover servers via the `RedisConfig` or active connections
-  ///   let connections = client.active_connections().await?;
-  ///
-  ///   // ping each node in the cluster individually
-  ///   for server in connections.into_iter() {
-  ///     let _: () = client.with_cluster_node(server).ping().await?;
-  ///   }
-  ///
-  ///   // or use the cached cluster routing table to discover servers
-  ///   let servers = client
-  ///     .cached_cluster_state()
-  ///     .expect("Failed to read cached cluster state")
-  ///     .unique_primary_nodes();
-  ///   for server in servers {
-  ///     // verify the server address with `CLIENT INFO`
-  ///     let server_addr = client
-  ///       .with_cluster_node(&server)
-  ///       .client_info::<String>()
-  ///       .await?
-  ///       .split(" ")
-  ///       .find_map(|s| {
-  ///         let parts: Vec<&str> = s.split("=").collect();
-  ///         if parts[0] == "laddr" {
-  ///           Some(parts[1].to_owned())
-  ///         } else {
-  ///           None
-  ///         }
-  ///       })
-  ///       .expect("Failed to read or parse client info.");
-  ///
-  ///     assert_eq!(server_addr, server.to_string());
-  ///   }
-  ///
-  ///   Ok(())
-  /// }
-  /// ```
   pub fn with_cluster_node<S>(&self, server: S) -> Node
   where
     S: Into<Server>,

--- a/src/clients/replica.rs
+++ b/src/clients/replica.rs
@@ -35,46 +35,6 @@ use tokio::sync::oneshot::channel as oneshot_channel;
 /// or when any connection closes.
 ///
 /// [Redis replication is asynchronous](https://redis.io/docs/management/replication/).
-// ### Cluster Replication
-//
-// In a clustered deployment replicas may redirect callers back to primary nodes, even with read-only commands,
-// depending on the server configuration. The client will automatically follow these redirections, but callers should
-// be aware of this behavior for monitoring or tracing purposes.
-//
-// #### Example
-//
-// ```bash
-// // connect to a primary node, print cluster and replica info, and `GET bar`
-// foo@d85c70fd4fc0:/project$ redis-cli -h 172.21.0.5 -p 30001
-// 172.21.0.5:30001> cluster nodes
-// 60ca8d301ef624956e847e6e6ecc865a36513bbe 172.21.0.3:30001@40001 slave f837e4056f564ab7fd69c24264279a1bd81d6420 0 1674165394000 3 connected
-// ddc30573f0c7ee1f79d7f263e2f83d7b83ad0ba0 172.21.0.8:30001@40001 slave 101b2a992c6c909d807d4c5fbd149bcc28e63ef8 0 1674165396000 2 connected
-// 101b2a992c6c909d807d4c5fbd149bcc28e63ef8 172.21.0.2:30001@40001 master - 0 1674165395807 2 connected 5461-10922
-// 38a7f9d3e440a37adf42f2ceddd9ad52bfb4186e 172.21.0.7:30001@40001 slave bd48cbd28cd927a284bab4424bd41b077a25acb6 0 1674165396810 1 connected
-// f837e4056f564ab7fd69c24264279a1bd81d6420 172.21.0.4:30001@40001 master - 0 1674165395000 3 connected 10923-16383
-// bd48cbd28cd927a284bab4424bd41b077a25acb6 172.21.0.5:30001@40001 myself,master - 0 1674165393000 1 connected 0-5460
-// 172.21.0.5:30001> info replication
-// # Replication
-// role:master
-// connected_slaves:1
-// slave0:ip=172.21.0.7,port=30001,state=online,offset=183696,lag=0
-// [truncated]
-// 172.21.0.5:30001> get bar
-// "2"
-//
-// // connect to the associated replica and `GET bar`
-// foo@d85c70fd4fc0:/project$ redis-cli -h 172.21.0.7 -p 30001
-// 172.21.0.7:30001> role
-// 1) "slave"
-// 2) "172.21.0.5"
-// 3) (integer) 30001
-// 4) "connected"
-// 5) (integer) 185390
-// 172.21.0.7:30001> get bar
-// (error) MOVED 5061 172.21.0.5:30001
-// ```
-//
-// **This can result in unexpected latency or errors depending on the client configuration.**
 #[derive(Clone)]
 #[cfg_attr(docsrs, doc(cfg(feature = "replicas")))]
 pub struct Replicas {

--- a/src/modules/mocks.rs
+++ b/src/modules/mocks.rs
@@ -223,7 +223,7 @@ impl Mocks for SimpleMap {
 ///
 /// ```rust
 /// #[tokio::test]
-/// async fn should_use_echo_mock() {
+/// async fn should_use_buffer_mock() {
 ///   let buffer = Arc::new(Buffer::new());
 ///   let config = RedisConfig {
 ///     mocks: buffer.clone(),

--- a/src/modules/response.rs
+++ b/src/modules/response.rs
@@ -274,7 +274,17 @@ where
           Ok(vec![T::from_value(RedisValue::String(string))?])
         }
       },
-      RedisValue::Array(values) => T::from_values(values),
+      RedisValue::Array(values) => {
+        if values.len() > 0 {
+          if let RedisValue::Array(_) = &values[0] {
+            values.into_iter().map(|x| T::from_value(x)).collect()
+          } else {
+            T::from_values(values)
+          }
+        } else {
+          Ok(vec![])
+        }
+      },
       RedisValue::Map(map) => {
         // not being able to use collect() here is unfortunate
         let out = Vec::with_capacity(map.len() * 2);

--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -39,7 +39,7 @@ use crate::protocol::tls::TlsConnector;
 #[cfg(feature = "replicas")]
 use crate::{
   protocol::{connection, responders::ResponseKind},
-  router::replicas,
+  types::RedisValue,
 };
 #[cfg(feature = "enable-rustls")]
 use std::convert::TryInto;
@@ -727,35 +727,63 @@ impl RedisTransport {
     .await
   }
 
-  /// Run and parse the output from `INFO replication`.
+  /// Send `READONLY` to the server.
   #[cfg(feature = "replicas")]
-  pub async fn info_replication(
-    &mut self,
-    inner: &Arc<RedisClientInner>,
-    timeout: Option<u64>,
-  ) -> Result<Option<String>, RedisError> {
-    let timeout = connection_timeout(timeout);
-    let command = RedisCommand::new(RedisCommandKind::Info, vec!["replication".into()]);
+  pub async fn readonly(&mut self, inner: &Arc<RedisClientInner>, timeout: Option<u64>) -> Result<(), RedisError> {
+    if !inner.config.server.is_clustered() {
+      return Ok(());
+    }
 
+    let timeout = connection_timeout(timeout);
     utils::apply_timeout(
       async {
-        self
-          .request_response(command, inner.is_resp3())
-          .await
-          .map(|f| f.as_str().map(|s| s.to_owned()))
+        _debug!(inner, "Sending READONLY to {}", self.server);
+        let command = RedisCommand::new(RedisCommandKind::Readonly, vec![]);
+        let response = self.request_response(command, inner.is_resp3()).await?;
+        let _ = protocol_utils::frame_to_single_result(response)?;
+
+        Ok::<_, RedisError>(())
       },
       timeout,
     )
     .await
   }
 
-  #[cfg(not(feature = "replicas"))]
-  pub async fn info_replication(
+  /// Send the `ROLE` command to the server.
+  #[cfg(feature = "replicas")]
+  pub async fn role(
     &mut self,
-    _: &Arc<RedisClientInner>,
-    _: Option<u64>,
-  ) -> Result<Option<String>, RedisError> {
-    Ok(None)
+    inner: &Arc<RedisClientInner>,
+    timeout: Option<u64>,
+  ) -> Result<RedisValue, RedisError> {
+    let timeout = connection_timeout(timeout);
+    let command = RedisCommand::new(RedisCommandKind::Role, vec![]);
+
+    utils::apply_timeout(
+      async {
+        self
+          .request_response(command, inner.is_resp3())
+          .await
+          .and_then(protocol_utils::frame_to_results_raw)
+      },
+      timeout,
+    )
+    .await
+  }
+
+  /// Discover connected replicas via the ROLE command.
+  #[cfg(feature = "replicas")]
+  pub async fn discover_replicas(&mut self, inner: &Arc<RedisClientInner>) -> Result<Vec<Server>, RedisError> {
+    self
+      .role(inner, None)
+      .await
+      .and_then(protocol_utils::parse_master_role_replicas)
+  }
+
+  /// Discover connected replicas via the ROLE command.
+  #[cfg(not(feature = "replicas"))]
+  pub async fn discover_replicas(&mut self, _: &Arc<RedisClientInner>) -> Result<Vec<Server>, RedisError> {
+    Ok(Vec::new())
   }
 
   /// Split the transport into reader/writer halves.
@@ -857,18 +885,13 @@ impl RedisWriter {
   }
 
   #[cfg(feature = "replicas")]
-  pub async fn info_replication(&mut self, inner: &Arc<RedisClientInner>) -> Result<Vec<Server>, RedisError> {
-    let command = RedisCommand::new(RedisCommandKind::Info, vec!["replication".into()]);
-    let frame = connection::request_response(inner, self, command, None)
-      .await?
-      .as_str()
-      .map(|s| s.to_owned())
-      .ok_or(RedisError::new(
-        RedisErrorKind::Replica,
-        "Failed to read replication info.",
-      ))?;
+  pub async fn discover_replicas(&mut self, inner: &Arc<RedisClientInner>) -> Result<Vec<Server>, RedisError> {
+    let command = RedisCommand::new(RedisCommandKind::Role, vec![]);
+    let role = connection::request_response(inner, self, command, None)
+      .await
+      .and_then(protocol_utils::frame_to_results_raw)?;
 
-    Ok(replicas::parse_info_replication(frame))
+    protocol_utils::parse_master_role_replicas(role)
   }
 
   /// Check if the connection is connected and can send frames.
@@ -937,10 +960,20 @@ impl RedisWriter {
   ///
   /// Returns the in-flight commands that had not received a response.
   pub async fn graceful_close(mut self) -> CommandBuffer {
-    let _ = self.sink.close().await;
-    if let Some(mut reader) = self.reader {
-      let _ = reader.wait().await;
-    }
+    let timeout = globals().default_connection_timeout_ms();
+    let _ = utils::apply_timeout(
+      async {
+        let _ = self.sink.close().await;
+        if let Some(mut reader) = self.reader {
+          let _ = reader.wait().await;
+        }
+
+        Ok::<_, RedisError>(())
+      },
+      timeout,
+    )
+    .await;
+
     self.buffer.lock().drain(..).collect()
   }
 }

--- a/src/protocol/tls.rs
+++ b/src/protocol/tls.rs
@@ -96,7 +96,8 @@ impl Eq for TlsHostMapping {}
 ///
 /// Note: the `hostnames` field is only necessary to use with certain clustered deployments.
 ///
-/// ```rust no_compile no_run
+/// ```rust no_run
+/// # use fred::types::*;
 /// let config = TlsConfig {
 ///   // or use `TlsConnector::default_rustls()`
 ///   connector: TlsConnector::default_native_tls(),

--- a/src/router/commands.rs
+++ b/src/router/commands.rs
@@ -95,7 +95,7 @@ async fn write_with_backpressure(
       Some(command) => command,
       None => return Err(RedisError::new(RedisErrorKind::Unknown, "Missing command.")),
     };
-    // FIXME clean this up
+    // TODO clean this up
     let rx = match _backpressure {
       Some(backpressure) => match backpressure.wait(inner, &mut command).await {
         Ok(Some(rx)) => Some(rx),

--- a/src/router/utils.rs
+++ b/src/router/utils.rs
@@ -24,8 +24,6 @@ use tokio::{
   sync::{mpsc::UnboundedReceiver, oneshot::channel as oneshot_channel},
 };
 
-#[cfg(all(feature = "metrics", feature = "partial-tracing"))]
-use crate::trace;
 #[cfg(feature = "check-unresponsive")]
 use futures::future::Either;
 #[cfg(feature = "check-unresponsive")]
@@ -72,7 +70,7 @@ pub fn check_backpressure(
 #[cfg(feature = "partial-tracing")]
 fn set_command_trace(inner: &Arc<RedisClientInner>, command: &mut RedisCommand) {
   if inner.should_trace() {
-    trace::set_network_span(inner, command, true);
+    crate::trace::set_network_span(inner, command, true);
   }
 }
 

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -309,7 +309,8 @@ pub struct PerformanceConfig {
   pub auto_pipeline:                 bool,
   /// The maximum number of times the client will attempt to send a command.
   ///
-  /// This value be incremented on a command whenever the connection closes while the command is in-flight.
+  /// This value be incremented whenever the connection closes while the command is in-flight or following a
+  /// MOVED/ASK error.
   ///
   /// Default: `3`
   pub max_command_attempts:          u32,

--- a/tests/docker/runners/bash/sentinel-features.sh
+++ b/tests/docker/runners/bash/sentinel-features.sh
@@ -10,7 +10,7 @@ do
   fi
 done
 
-FEATURES="network-logs sentinel-tests sentinel-auth"
+FEATURES="network-logs debug-ids sentinel-tests sentinel-auth replicas"
 
 if [ -z "$FRED_CI_NEXTEST" ]; then
   cargo test --release --lib --tests --features "$FEATURES" -- --test-threads=1 "$@"

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -67,6 +67,8 @@ mod other {
   #[cfg(feature = "replicas")]
   cluster_test!(other, should_replica_set_and_get_not_lazy);
   #[cfg(feature = "replicas")]
+  cluster_test!(other, should_use_cluster_replica_without_redirection);
+  #[cfg(feature = "replicas")]
   cluster_test!(other, should_pipeline_with_replicas);
 }
 


### PR DESCRIPTION
* Fix cluster replica discovery with Elasticache
* Fix cluster replica `READONLY` usage
* Fix compilation error with `full-tracing`
* Support `Vec<(T1, T2, ...)>` with `FromRedis`