### PR TITLE
derive `Debug` for `RedisClient`

### DIFF
--- a/src/clients/redis.rs
+++ b/src/clients/redis.rs
@@ -40,7 +40,7 @@ use crate::{clients::Caching, interfaces::TrackingInterface};
 use crate::clients::Replicas;
 
 /// The primary Redis client struct.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RedisClient {
   pub(crate) inner: Arc<RedisClientInner>,
 }


### PR DESCRIPTION
This allows `RedisClient` to be used where `Debug` is required.