### PR TITLE
feat: using IndexMap to preserve the RedisMap items' original order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ sha-1 = { version = "0.10", optional = true }
 rand = "0.8"
 semver = "1.0"
 socket2 = "0.5"
+indexmap = "2.0"
 async-trait = { version = "0.1" }
 rustls = { version = "0.21", optional = true }
 native-tls = { version = "0.2", optional = true }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,6 +20,7 @@ use futures::{
   Future,
   TryFutureExt,
 };
+use indexmap::IndexMap;
 use parking_lot::{Mutex, RwLock};
 use rand::{self, distributions::Alphanumeric, Rng};
 use redis_protocol::resp3::types::Frame as Resp3Frame;
@@ -568,7 +569,7 @@ pub fn add_jitter(delay: u64, jitter: u32) -> u64 {
   delay.saturating_add(rand::thread_rng().gen_range(0 .. jitter as u64))
 }
 
-pub fn into_redis_map<I, K, V>(mut iter: I) -> Result<HashMap<RedisKey, RedisValue>, RedisError>
+pub fn into_redis_map<I, K, V>(mut iter: I) -> Result<IndexMap<RedisKey, RedisValue>, RedisError>
 where
   I: Iterator<Item = (K, V)>,
   K: TryInto<RedisKey>,
@@ -578,7 +579,7 @@ where
 {
   let (lower, upper) = iter.size_hint();
   let capacity = if let Some(upper) = upper { upper } else { lower };
-  let mut out = HashMap::with_capacity(capacity);
+  let mut out = IndexMap::with_capacity(capacity);
 
   while let Some((key, value)) = iter.next() {
     out.insert(to!(key)?, to!(value)?);
@@ -609,7 +610,7 @@ pub fn flatten_nested_array_values(value: RedisValue, depth: usize) -> RedisValu
       RedisValue::Array(out)
     },
     RedisValue::Map(values) => {
-      let mut out = HashMap::with_capacity(values.len());
+      let mut out = IndexMap::with_capacity(values.len());
 
       for (key, value) in values.inner().into_iter() {
         let value = if value.is_array() {


### PR DESCRIPTION
I noticed that the items' order of  the `hscan` command result is arbitrary. 'Cause it used the `HashMap`.

And using ordered map `IndexMap` can correctly `hset` the `Vec-like` values one by one. 