### PR TITLE
7.0.1

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -565,7 +565,11 @@ where
 }
 
 pub fn add_jitter(delay: u64, jitter: u32) -> u64 {
-  delay.saturating_add(rand::thread_rng().gen_range(0 .. jitter as u64))
+  if jitter == 0 {
+    delay
+  } else {
+    delay.saturating_add(rand::thread_rng().gen_range(0 .. jitter as u64))
+  }
 }
 
 pub fn into_redis_map<I, K, V>(mut iter: I) -> Result<HashMap<RedisKey, RedisValue>, RedisError>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -837,6 +837,11 @@ mod tests {
   }
 
   #[test]
+  fn should_not_panic_with_zero_jitter() {
+    assert_eq!(add_jitter(10, 0), 10);
+  }
+
+  #[test]
   fn should_flatten_xread_example() {
     // 127.0.0.1:6379> xread count 2 streams foo bar 1643479648480-0 1643479834990-0
     // 1) 1) "foo"


### PR DESCRIPTION
**Description**
Discovered a bug which would cause a panic if jitter was 0 when it would add the jitter to the delay.

**Solution**
Adding a check to return the delay if jitter is 0.

**Test**
Before fix:
<img width="1405" alt="Screen Shot 2023-11-17 at 1 41 25 pm" src="https://github.com/aembke/fred.rs/assets/11872490/b6983d4f-3b63-4820-a7ba-6cd67c485a04">

After fix:
<img width="807" alt="Screen Shot 2023-11-17 at 1 41 42 pm" src="https://github.com/aembke/fred.rs/assets/11872490/b1e6b8ea-8bf0-4b9f-b8cb-1d58aca016dd">
