### PR TITLE
fix: prevent redis failure if values is empty in hset and hmset

### DIFF
--- a/src/commands/impls/hashes.rs
+++ b/src/commands/impls/hashes.rs
@@ -87,6 +87,9 @@ pub async fn hmget<C: ClientLike>(client: &C, key: RedisKey, fields: MultipleKey
 }
 
 pub async fn hmset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -> Result<RedisValue, RedisError> {
+  if values.is_empty() {
+    return Ok(RedisValue::Boolean(false));
+  }
   let frame = utils::request_response(client, move || {
     let mut args = Vec::with_capacity(1 + (values.len() * 2));
     args.push(key.into());
@@ -103,6 +106,9 @@ pub async fn hmset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -
 }
 
 pub async fn hset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -> Result<RedisValue, RedisError> {
+  if values.is_empty() {
+    return Ok(RedisValue::Boolean(false));
+  }
   let frame = utils::request_response(client, move || {
     let mut args = Vec::with_capacity(1 + (values.len() * 2));
     args.push(key.into());

--- a/src/commands/impls/hashes.rs
+++ b/src/commands/impls/hashes.rs
@@ -87,9 +87,6 @@ pub async fn hmget<C: ClientLike>(client: &C, key: RedisKey, fields: MultipleKey
 }
 
 pub async fn hmset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -> Result<RedisValue, RedisError> {
-  if values.is_empty() {
-    return Ok(RedisValue::Boolean(false));
-  }
   let frame = utils::request_response(client, move || {
     let mut args = Vec::with_capacity(1 + (values.len() * 2));
     args.push(key.into());
@@ -106,9 +103,6 @@ pub async fn hmset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -
 }
 
 pub async fn hset<C: ClientLike>(client: &C, key: RedisKey, values: RedisMap) -> Result<RedisValue, RedisError> {
-  if values.is_empty() {
-    return Ok(RedisValue::Boolean(false));
-  }
   let frame = utils::request_response(client, move || {
     let mut args = Vec::with_capacity(1 + (values.len() * 2));
     args.push(key.into());

--- a/src/trace/enabled.rs
+++ b/src/trace/enabled.rs
@@ -70,12 +70,7 @@ pub fn create_command_span(inner: &Arc<RedisClientInner>) -> Span {
 
 #[cfg(feature = "full-tracing")]
 pub fn create_args_span(parent: Option<TraceId>, inner: &Arc<RedisClientInner>) -> Span {
-  span_lvl!(
-    inner.full_tracing_span_level(),
-    parent: parent,
-    "prepare_args",
-    num_args = Empty
-  )
+  span_lvl!(inner.full_tracing_span_level(), parent: parent, "prepare_args", num_args = Empty)
 }
 
 #[cfg(not(feature = "full-tracing"))]

--- a/src/trace/enabled.rs
+++ b/src/trace/enabled.rs
@@ -70,7 +70,12 @@ pub fn create_command_span(inner: &Arc<RedisClientInner>) -> Span {
 
 #[cfg(feature = "full-tracing")]
 pub fn create_args_span(parent: Option<TraceId>, inner: &Arc<RedisClientInner>) -> Span {
-  span_lvl!(inner.full_tracing_span_level(), parent: parent, "prepare_args", num_args = Empty)
+  span_lvl!(
+    inner.full_tracing_span_level(),
+    parent: parent,
+    "prepare_args",
+    num_args = Empty
+  )
 }
 
 #[cfg(not(feature = "full-tracing"))]


### PR DESCRIPTION
hset and hmset command if used with empty Vec as values would throw below error.
```
[src/main.rs:18] result = Err(
    Redis Error - kind: Unknown, details: ERR wrong number of arguments for 'hmset' command,
)
```

With This PR, this problem is eliminated by early returning `RedisValue::Boolean(false)` from hset and hmset functions if values is found to be empty.
