### PR TITLE
8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 8.0.1
 
-* Add a cleaner `init` interface.
-* Fix RESP3 connection init when used without a password
+* Add a shorthand `init` interface.
+* Fix RESP3 connection init when used without a password.
 
 ## 8.0.0
 
@@ -10,7 +10,7 @@
 * Add a Redis TimeSeries interface.
 * Improve unresponsive connection checks.
 * Move several feature flags to configuration options.
-* Add a benchmarking tool.
+* Add a [benchmarking](bin/benchmark) tool.
 * Update to Rustls 0.22.
 * Add several new connection configuration options.
 * Add a `fail_fast` flag to commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+## 8.0.1
+
+* Add a cleaner `init` interface.
+* Fix RESP3 connection init when used without a password
+
 ## 8.0.0
 
 * Remove the `globals` interface.
 * Support unix domain sockets.
+* Add a Redis TimeSeries interface.
 * Improve unresponsive connection checks.
 * Move several feature flags to configuration options.
 * Add a benchmarking tool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.0.1
 
 * Add a shorthand `init` interface.
+* Fix cluster replica failover with unresponsive connections.
 * Fix RESP3 connection init when used without a password.
 
 ## 8.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing
 ===========
 
-This document gives some background on how the library is structured and how to contribute.
+This document gives some background on how the library is structured and how to contribute. It focuses primarily on how to add new commands. See the [design doc](docs/README.md) for more background on how the library is designed. 
 
 # General
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
-workspace = { members = ["bin/benchmark_metrics"] }
 [package]
 name = "fred"
-version = "8.0.0"
+version = "8.0.1"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2021"
 description = "An async Redis client built on Tokio."
@@ -146,9 +145,8 @@ default-nil-types = []
 codec = []
 unix-sockets = []
 # Redis Stack Features
-redis-stack = ["redis-json", "time-series", "redisearch"]
+redis-stack = ["redis-json", "time-series"]
 redis-json = ["serde-json"]
-redisearch = []
 time-series = []
 # Debugging Features
 debug-ids = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,8 +146,9 @@ default-nil-types = []
 codec = []
 unix-sockets = []
 # Redis Stack Features
-redis-stack = ["redis-json", "time-series"]
+redis-stack = ["redis-json", "time-series", "redisearch"]
 redis-json = ["serde-json"]
+redisearch = []
 time-series = []
 # Debugging Features
 debug-ids = []

--- a/README.md
+++ b/README.md
@@ -88,5 +88,4 @@ See the [examples](https://github.com/aembke/fred.rs/tree/main/examples) for mor
 | sha-1                   |         | Enable an interface for hashing Lua scripts.                                                                                                             |
 | unix-sockets            |         | Enable Unix socket support.                                                                                                                              |
 | time-series             |         | Enable an interface for [Redis Timeseries](https://redis.io/docs/data-types/timeseries/).                                                                |
-| redisearch              |         | Enable an interface for [RediSearch](https://github.com/RediSearch/RediSearch).                                                                                                                  |
 

--- a/README.md
+++ b/README.md
@@ -9,29 +9,28 @@ Fred
 
 An async Redis client for Rust and Tokio.
 
-## Example 
+## Example
 
 ```rust
 use fred::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
-  let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
- 
+  let client = RedisClient::default(); 
+  client.init().await?;
+
   // convert responses to many common Rust types
   let foo: Option<String> = client.get("foo").await?;
   assert!(foo.is_none());
-  
+
   client.set("foo", "bar", None, None, false).await?;
   // or use turbofish to declare response types
   println!("Foo: {:?}", client.get::<String, _>("foo").await?);
-  
+
   // or use a lower level interface for responses to defer parsing, etc
   let foo: RedisValue = client.get("foo").await?;
   assert_eq!(foo.as_str().unwrap(), "bar");
-  
+
   client.quit().await?;
   Ok(())
 }
@@ -62,30 +61,32 @@ See the [examples](https://github.com/aembke/fred.rs/tree/main/examples) for mor
 
 ## Build Features 
 
-| Name                    | Default | Description                                                                                                                                                                                          |
-|-------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| transactions            | x       | Enable a [Transaction](https://redis.io/docs/interact/transactions/) interface.                                                                                                                      |
-| enable-native-tls       |         | Enable TLS support via [native-tls](https://crates.io/crates/native-tls).                                                                                                                            |
-| enable-rustls           |         | Enable TLS support via [rustls](https://crates.io/crates/rustls).                                                                                                                                    |
-| vendored-openssl        |         | Enable the `native-tls/vendored` feature.                                                                                                                                                            |
-| metrics                 |         | Enable the metrics interface to track overall latency, network latency, and request/response sizes.                                                                                                  |
-| full-tracing            |         | Enable full [tracing](./src/trace/README.md) support. This can emit a lot of data.                                                                                                                   |
-| partial-tracing         |         | Enable partial [tracing](./src/trace/README.md) support, only emitting traces for top level commands and network latency.                                                                            |
-| blocking-encoding       |         | Use a blocking task for encoding or decoding frames. This can be useful for clients that send or receive large payloads, but requires a multi-thread Tokio runtime.                                  |
+| Name                    | Default | Description                                                                                                                                              |
+|-------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| transactions            | x       | Enable a [Transaction](https://redis.io/docs/interact/transactions/) interface.                                                                          |
+| enable-native-tls       |         | Enable TLS support via [native-tls](https://crates.io/crates/native-tls).                                                                                |
+| enable-rustls           |         | Enable TLS support via [rustls](https://crates.io/crates/rustls).                                                                                        |
+| vendored-openssl        |         | Enable the `native-tls/vendored` feature.                                                                                                                |
+| metrics                 |         | Enable the metrics interface to track overall latency, network latency, and request/response sizes.                                                      |
+| full-tracing            |         | Enable full [tracing](./src/trace/README.md) support. This can emit a lot of data.                                                                       |
+| partial-tracing         |         | Enable partial [tracing](./src/trace/README.md) support, only emitting traces for top level commands and network latency.                                |
+| blocking-encoding       |         | Use a blocking task for encoding or decoding frames. This can be useful for clients that send or receive large payloads, but requires a multi-thread Tokio runtime. |
 | network-logs            |         | Enable TRACE level logging statements that will print out all data sent to or received from the server. These are the only logging statements that can ever contain potentially sensitive user data. |
-| custom-reconnect-errors |         | Enable an interface for callers to customize the types of errors that should automatically trigger reconnection logic.                                                                               |
-| monitor                 |         | Enable an interface for running the `MONITOR` command.                                                                                                                                               |
-| sentinel-client         |         | Enable an interface for communicating directly with Sentinel nodes. This is not necessary to use normal Redis clients behind a sentinel layer.                                                       |
-| sentinel-auth           |         | Enable an interface for using different authentication credentials to sentinel nodes.                                                                                                                |
-| subscriber-client       |         | Enable a subscriber client interface that manages channel subscription state for callers.                                                                                                            |
-| serde-json              |         | Enable an interface to automatically convert Redis types to JSON via `serde-json`.                                                                                                                   |
-| mocks                   |         | Enable a mocking layer interface that can be used to intercept and process commands in tests.                                                                                                        |
-| dns                     |         | Enable an interface that allows callers to override the DNS lookup logic.                                                                                                                            |
-| replicas                |         | Enable an interface that routes commands to replica nodes.                                                                                                                                           |
-| client-tracking         |         | Enable a [client tracking](https://redis.io/docs/manual/client-side-caching/) interface.                                                                                                             |
-| default-nil-types       |         | Enable a looser parsing interface for `nil` values.                                                                                                                                                  |
-| redis-json              |         | Enable an interface for [RedisJSON](https://github.com/RedisJSON/RedisJSON).                                                                                                                         |
-| codec                   |         | Enable a lower level framed codec interface for use with [tokio-util](https://docs.rs/tokio-util/latest/tokio_util/codec/index.html).                                                                |
-| sha-1                   |         | Enable an interface for hashing Lua scripts.                                                                                                                                                         |
-| unix-sockets            |         | Enable Unix socket support.                                                                                                                                                                          |
-| time-series             |         | Enable an interface for [Redis Timeseries](https://redis.io/docs/data-types/timeseries/).                                                                                                            |
+| custom-reconnect-errors |         | Enable an interface for callers to customize the types of errors that should automatically trigger reconnection logic.                                   |
+| monitor                 |         | Enable an interface for running the `MONITOR` command.                                                                                                   |
+| sentinel-client         |         | Enable an interface for communicating directly with Sentinel nodes. This is not necessary to use normal Redis clients behind a sentinel layer.           |
+| sentinel-auth           |         | Enable an interface for using different authentication credentials to sentinel nodes.                                                                    |
+| subscriber-client       |         | Enable a subscriber client interface that manages channel subscription state for callers.                                                                |
+| serde-json              |         | Enable an interface to automatically convert Redis types to JSON via `serde-json`.                                                                       |
+| mocks                   |         | Enable a mocking layer interface that can be used to intercept and process commands in tests.                                                            |
+| dns                     |         | Enable an interface that allows callers to override the DNS lookup logic.                                                                                |
+| replicas                |         | Enable an interface that routes commands to replica nodes.                                                                                               |
+| client-tracking         |         | Enable a [client tracking](https://redis.io/docs/manual/client-side-caching/) interface.                                                                 |
+| default-nil-types       |         | Enable a looser parsing interface for `nil` values.                                                                                                      |
+| redis-json              |         | Enable an interface for [RedisJSON](https://github.com/RedisJSON/RedisJSON).                                                                             |
+| codec                   |         | Enable a lower level framed codec interface for use with [tokio-util](https://docs.rs/tokio-util/latest/tokio_util/codec/index.html).                    |
+| sha-1                   |         | Enable an interface for hashing Lua scripts.                                                                                                             |
+| unix-sockets            |         | Enable Unix socket support.                                                                                                                              |
+| time-series             |         | Enable an interface for [Redis Timeseries](https://redis.io/docs/data-types/timeseries/).                                                                |
+| redisearch              |         | Enable an interface for [RediSearch](https://github.com/RediSearch/RediSearch).                                                                                                                  |
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Commands are processed in series, but the `auto_pipeline` flag controls whether 
 
 However, this has some drawbacks:
 * Once a command is in the `UnboundedSender` channel it's difficult to inspect or remove. There's no practical way to get any kind of random access into this.
-* It can be difficult to create a "fast lane" for "special" commands with this model. For example, forcing a reconnection should take precedence over a blocking command. This is more difficult to implement with this model.
+* It can be difficult to preempt commands with this model. For example, forcing a reconnection should take precedence over a blocking command. This is more difficult to implement with this model.
 * Callers should at least be aware of this channel so that they're aware of how server failure modes can lead to increased memory usage. This makes it perhaps surprisingly important to properly tune reconnection or backpressure settings, especially if memory is in short supply.
 * Some things that would ideally be synchronous must instead be asynchronous. For example, I've often wanted a synchronous interface to inspect active connections.
 

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -36,8 +36,7 @@ async fn main() {
     .build_pool(pool_size)
     .expect("Failed to create redis pool");
 
-  let _ = pool.connect();
-  pool.wait_for_connect().await.expect("Failed to connect to redis");
+  pool.init().await.expect("Failed to connect to redis");
   info!("Connected to Redis");
 
   let app = Router::new()

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -51,31 +51,38 @@ async fn main() {
   axum::serve(listener, app).await.unwrap();
 }
 
+fn map_error(err: RedisError) -> (u16, Body) {
+  let details: Body = err.details().to_string().into();
+  let code = if *err.kind() == RedisErrorKind::NotFound {
+    404
+  } else if err.details().starts_with("WRONGTYPE") {
+    400
+  } else {
+    500
+  };
+
+  (code, details)
+}
+
 async fn get_kv(Path(key): Path<String>, State(state): State<AppState>) -> impl IntoResponse {
   debug!("get {}", key);
 
   let (code, val) = match state.pool.get::<Option<Bytes>, _>(key).await {
-    Ok(Some(val)) => (200, val),
+    Ok(Some(val)) => (200, val.into()),
     Ok(None) => (404, "Not found".into()),
-    Err(err) if *err.kind() == RedisErrorKind::NotFound => (404, err.to_string().into()),
-    Err(err) if err.details().starts_with("WRONGTYPE") => (400, err.to_string().into()),
-    Err(err) => (500, err.to_string().into()),
+    Err(err) => map_error(err),
   };
-
-  Response::builder().status(code).body(Body::from(val)).unwrap()
+  Response::builder().status(code).body(val).unwrap()
 }
 
 async fn set_kv(Path(key): Path<String>, State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
   debug!("set {} {}", key, String::from_utf8_lossy(&body));
 
   let (code, val) = match state.pool.set::<Bytes, _, _>(key, body, None, None, false).await {
-    Ok(val) => (200, val),
-    Err(err) if *err.kind() == RedisErrorKind::NotFound => (404, err.to_string().into()),
-    Err(err) if err.details().starts_with("WRONGTYPE") => (400, err.to_string().into()),
-    Err(err) => (500, err.to_string().into()),
+    Ok(val) => (200, val.into()),
+    Err(err) => map_error(err),
   };
-
-  Response::builder().status(code).body(Body::from(val)).unwrap()
+  Response::builder().status(code).body(val).unwrap()
 }
 
 async fn del_kv(Path(key): Path<String>, State(state): State<AppState>) -> impl IntoResponse {
@@ -83,13 +90,10 @@ async fn del_kv(Path(key): Path<String>, State(state): State<AppState>) -> impl 
 
   let (code, val) = match state.pool.del::<i64, _>(key).await {
     Ok(val) if val == 0 => (404, "Not Found.".into()),
-    Ok(val) => (200, val.to_string()),
-    Err(err) if *err.kind() == RedisErrorKind::NotFound => (404, err.to_string()),
-    Err(err) if err.details().starts_with("WRONGTYPE") => (400, err.to_string()),
-    Err(err) => (500, err.to_string()),
+    Ok(val) => (200, val.to_string().into()),
+    Err(err) => map_error(err),
   };
-
-  Response::builder().status(code).body(Body::from(val)).unwrap()
+  Response::builder().status(code).body(val).unwrap()
 }
 
 async fn incr_kv(Path(key): Path<String>, State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
@@ -100,13 +104,10 @@ async fn incr_kv(Path(key): Path<String>, State(state): State<AppState>, body: B
   debug!("incr {} by {}", key, count);
 
   let (code, val) = match state.pool.incr_by::<i64, _>(key, count).await {
-    Ok(val) => (200, val.to_string()),
-    Err(err) if *err.kind() == RedisErrorKind::NotFound => (404, err.to_string()),
-    Err(err) if err.details().starts_with("WRONGTYPE") => (400, err.to_string()),
-    Err(err) => (500, err.to_string()),
+    Ok(val) => (200, val.to_string().into()),
+    Err(err) => map_error(err),
   };
-
-  Response::builder().status(code).body(Body::from(val)).unwrap()
+  Response::builder().status(code).body(val).unwrap()
 }
 
 // example usage with curl:

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -89,7 +89,7 @@ async fn del_kv(Path(key): Path<String>, State(state): State<AppState>) -> impl 
   debug!("del {}", key);
 
   let (code, val) = match state.pool.del::<i64, _>(key).await {
-    Ok(val) if val == 0 => (404, "Not Found.".into()),
+    Ok(0) => (404, "Not Found.".into()),
     Ok(val) => (200, val.to_string().into()),
     Err(err) => map_error(err),
   };

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -33,9 +33,8 @@ async fn main() -> Result<(), RedisError> {
   let _client = Builder::from_config(config).build()?;
   // or use default values
   let client = Builder::default_centralized().build()?;
-  let connection_task = client.connect();
-  client.wait_for_connect().await?;
-
+  // callers can manage the tokio task driving the connections
+  let connection_task = client.init().await?;
   // convert response types to most common rust types
   let foo: Option<String> = client.get("foo").await?;
   println!("Foo: {:?}", foo);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::let_underscore_future)]
 
-use fred::{prelude::*, types::RespVersion};
-#[cfg(feature = "partial-tracing")]
-use fred::{tracing::Level, types::TracingConfig};
+use fred::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,31 +8,9 @@ use fred::{tracing::Level, types::TracingConfig};
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   // create a config from a URL
-  let _ = RedisConfig::from_url("redis://username:password@foo.com:6379/1")?;
-  // full configuration with testing values
-  let config = RedisConfig {
-    fail_fast: true,
-    server: ServerConfig::new_centralized("redis-main", 6379),
-    blocking: Blocking::Block,
-    username: Some("foo".into()),
-    password: Some("bar".into()),
-    version: RespVersion::RESP2,
-    database: None,
-    #[cfg(any(feature = "enable-native-tls", feature = "enable-rustls"))]
-    tls: None,
-    #[cfg(feature = "partial-tracing")]
-    tracing: TracingConfig {
-      enabled:                                             false,
-      default_tracing_level:                               Level::INFO,
-      #[cfg(feature = "full-tracing")]
-      full_tracing_level:                                  Level::DEBUG,
-    },
-    ..Default::default()
-  };
-  // see the Builder interface for more information
-  let _client = Builder::from_config(config).build()?;
-  // or use default values
-  let client = Builder::default_centralized().build()?;
+  let config = RedisConfig::from_url("redis://username:password@foo.com:6379/1")?;
+  // see the `Builder` interface for more information
+  let client = Builder::from_config(config).build()?;
   // callers can manage the tokio task driving the connections
   let connection_task = client.init().await?;
   // convert response types to most common rust types

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -11,11 +11,8 @@ async fn main() -> Result<(), RedisError> {
 
   let publisher_client = RedisClient::default();
   let subscriber_client = RedisClient::default();
-
-  let _ = publisher_client.connect();
-  let _ = subscriber_client.connect();
-  publisher_client.wait_for_connect().await?;
-  subscriber_client.wait_for_connect().await?;
+  publisher_client.init().await?;
+  subscriber_client.init().await?;
 
   let subscriber_jh = tokio::spawn(async move {
     loop {

--- a/examples/client_tracking.rs
+++ b/examples/client_tracking.rs
@@ -13,8 +13,7 @@ async fn resp3_tracking_interface_example() -> Result<(), RedisError> {
       config.version = RespVersion::RESP3;
     })
     .build()?;
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // spawn a task that processes invalidation messages.
   let _ = client.on_invalidation(|invalidation| {
@@ -50,13 +49,11 @@ async fn resp3_tracking_interface_example() -> Result<(), RedisError> {
 
 async fn resp2_basic_interface_example() -> Result<(), RedisError> {
   let subscriber = RedisClient::default();
-  let client = RedisClient::default();
+  let client = subscriber.clone_new();
 
   // RESP2 requires two connections
-  let _ = subscriber.connect();
-  let _ = client.connect();
-  subscriber.wait_for_connect().await?;
-  client.wait_for_connect().await?;
+  subscriber.init().await?;
+  client.init().await?;
 
   // the invalidation subscriber interface is the same as above even in RESP2 mode **as long as the `client-tracking`
   // feature is enabled**. if the feature is disabled then the message will appear on the `on_message` receiver.

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -11,8 +11,7 @@ use std::convert::TryInto;
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = Builder::default_centralized().build()?;
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
   client.lpush("foo", vec![1, 2, 3]).await?;
 
   // some types require TryInto

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -40,9 +40,7 @@ impl Resolve for TrustDnsResolver {
 async fn main() -> Result<(), RedisError> {
   let client = Builder::default_centralized().build()?;
   client.set_resolver(Arc::new(TrustDnsResolver::new())).await;
-
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // ...
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -66,8 +66,8 @@ async fn main() -> Result<(), RedisError> {
 async fn setup_pool() -> Result<(), RedisError> {
   let pool = Builder::default_centralized().build_pool(5)?;
 
-  // `select_all` does most of the work here but requires that the channel receivers implement `Stream`. unfortunately
-  // `tokio::sync::broadcast::Receiver` does not do this, so we use `tokio_stream::wrappers::BroadcastStream`.
+  // `select_all` does most of the work here but requires that the channel receivers implement `Stream`. the
+  // `tokio_stream::wrappers::BroadcastStream` wrapper can be used to do this.
   let error_rxs: Vec<_> = pool
     .clients()
     .iter()
@@ -94,8 +94,7 @@ async fn setup_pool() -> Result<(), RedisError> {
     }
   });
 
-  pool.connect();
-  pool.wait_for_connect().await?;
+  pool.init().await?;
 
   // ...
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -49,8 +49,7 @@ async fn main() -> Result<(), RedisError> {
     }
   });
 
-  client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // ...
 

--- a/examples/keyspace.rs
+++ b/examples/keyspace.rs
@@ -8,8 +8,7 @@ use tokio::time::sleep;
 async fn fake_traffic(client: &RedisClient, amount: usize) -> Result<(), RedisError> {
   // use a new client since the provided client is subscribed to keyspace events
   let client = client.clone_new();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   for idx in 0 .. amount {
     let key: RedisKey = format!("foo-{}", idx).into();
@@ -58,8 +57,7 @@ async fn centralized_keyspace_events() -> Result<(), RedisError> {
   });
 
   // connect after setting up the reconnection logic
-  subscriber.connect();
-  subscriber.wait_for_connect().await?;
+  subscriber.init().await?;
 
   let mut keyspace_rx = subscriber.keyspace_event_rx();
   // set up a task that listens for keyspace events
@@ -107,8 +105,7 @@ async fn clustered_keyspace_events() -> Result<(), RedisError> {
   });
 
   // connect after setting up the reconnection logic
-  subscriber.connect();
-  subscriber.wait_for_connect().await?;
+  subscriber.init().await?;
 
   let mut keyspace_rx = subscriber.keyspace_event_rx();
   // set up a task that listens for keyspace events

--- a/examples/lua.rs
+++ b/examples/lua.rs
@@ -18,8 +18,7 @@ static SCRIPTS: &[&str] = &[
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   for script in SCRIPTS.iter() {
     let hash = fred_utils::sha1_hash(script);
@@ -45,8 +44,7 @@ async fn main() -> Result<(), RedisError> {
 #[allow(dead_code)]
 async fn scripts() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   let script = Script::from_lua(SCRIPTS[0]);
   let _ = script.load(&client).await?;
@@ -60,8 +58,7 @@ async fn scripts() -> Result<(), RedisError> {
 #[allow(dead_code)]
 async fn functions() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   let echo_lua = include_str!("../tests/scripts/lua/echo.lua");
   let lib = Library::from_code(&client, echo_lua).await?;

--- a/examples/misc.rs
+++ b/examples/misc.rs
@@ -41,8 +41,7 @@ async fn main() -> Result<(), RedisError> {
     // use exponential backoff, starting at 100 ms and doubling on each failed attempt up to 30 sec
     .set_policy(ReconnectPolicy::new_exponential(0, 100, 30_000, 2))
     .build()?;
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // run all event listener functions in one task
   let events_task = client.on_any(

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -21,8 +21,7 @@ async fn main() -> Result<(), RedisError> {
   });
 
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   for idx in 0 .. 50 {
     client.set("foo", idx, Some(Expiration::EX(10)), None, false).await?;

--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -8,8 +8,7 @@ async fn main() -> Result<(), RedisError> {
   // the `auto_pipeline` config option determines whether the client will pipeline commands across tasks.
   // this example shows how to pipeline commands within one task.
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   let pipeline = client.pipeline();
   // commands are queued in memory

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -6,8 +6,7 @@ use fred::prelude::*;
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let pool = Builder::default_centralized().build_pool(5)?;
-  let _ = pool.connect();
-  pool.wait_for_connect().await?;
+  pool.init().await?;
 
   // all client types, including `RedisPool`, implement the same command interface traits so callers can often use
   // them interchangeably. in this example each command below will be sent round-robin to the underlying 5 clients.

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -11,11 +11,8 @@ use tokio::time::sleep;
 async fn main() -> Result<(), RedisError> {
   let publisher_client = RedisClient::default();
   let subscriber_client = publisher_client.clone_new();
-
-  let _ = publisher_client.connect();
-  let _ = subscriber_client.connect();
-  publisher_client.wait_for_connect().await?;
-  subscriber_client.wait_for_connect().await?;
+  publisher_client.init().await?;
+  subscriber_client.init().await?;
 
   // or use `message_rx()` to use the underlying `BroadcastReceiver` directly without spawning a new task
   let message_task = subscriber_client.on_message(|message| {
@@ -37,8 +34,7 @@ async fn main() -> Result<(), RedisError> {
 #[cfg(feature = "subscriber-client")]
 async fn subscriber_example() -> Result<(), RedisError> {
   let subscriber = Builder::default_centralized().build_subscriber_client()?;
-  let _ = subscriber.connect();
-  subscriber.wait_for_connect().await?;
+  subscriber.init().await?;
 
   // or use the `on_message` shorthand
   let mut message_stream = subscriber.message_rx();

--- a/examples/redis_json.rs
+++ b/examples/redis_json.rs
@@ -8,8 +8,7 @@ use serde_json::{json, Value};
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = Builder::default_centralized().build()?;
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // operate on objects
   let value = json!({

--- a/examples/scan.rs
+++ b/examples/scan.rs
@@ -6,14 +6,12 @@ use fred::{prelude::*, types::Scanner};
 use futures::stream::TryStreamExt;
 
 async fn create_fake_data(client: &RedisClient) -> Result<(), RedisError> {
-  for idx in 0 .. 50 {
-    client.set(format!("foo-{}", idx), idx, None, None, false).await?;
-  }
-  Ok(())
+  let values: Vec<(String, i64)> = (0 .. 50).map(|i| (format!("foo-{}", i), i)).collect();
+  client.mset(values).await
 }
 
 async fn delete_fake_data(client: &RedisClient) -> Result<(), RedisError> {
-  let keys: Vec<_> = (0 .. 50).into_iter().map(|i| format!("foo-{}", i)).collect();
+  let keys: Vec<_> = (0 .. 50).map(|i| format!("foo-{}", i)).collect();
   client.del(keys).await?;
   Ok(())
 }
@@ -71,7 +69,7 @@ async fn pool_scan_cluster_memory_example(pool: &RedisPool) -> Result<(), RedisE
       // pipeline the `MEMORY USAGE` calls
       let pipeline = pool.next().pipeline();
       for key in page.iter() {
-        let _: () = pipeline.memory_usage(key, Some(0)).await?;
+        pipeline.memory_usage(key, Some(0)).await?;
       }
       let sizes: Vec<Option<u64>> = pipeline.all().await?;
       assert_eq!(page.len(), sizes.len());

--- a/examples/scan.rs
+++ b/examples/scan.rs
@@ -21,8 +21,7 @@ async fn delete_fake_data(client: &RedisClient) -> Result<(), RedisError> {
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
   create_fake_data(&client).await?;
 
   // scan all keys in the keyspace, returning 10 keys per page

--- a/examples/sentinel.rs
+++ b/examples/sentinel.rs
@@ -27,8 +27,7 @@ async fn main() -> Result<(), RedisError> {
   };
 
   let client = Builder::from_config(config).build()?;
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   // ...
 

--- a/examples/serde_json.rs
+++ b/examples/serde_json.rs
@@ -16,14 +16,13 @@ struct Person {
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   let value = json!({
     "foo": "a",
     "bar": "b"
   });
-  let _: () = client.set("wibble", value.to_string(), None, None, false).await?;
+  client.set("wibble", value.to_string(), None, None, false).await?;
 
   // converting back to a json `Value` will also try to parse nested json strings. if a value looks like json, but
   // cannot be parsed as json, then it will be returned as a string.
@@ -37,7 +36,7 @@ async fn main() -> Result<(), RedisError> {
   };
 
   let serialized = serde_json::to_string(&person)?;
-  let _: () = client.set("foo", serialized, None, None, false).await?;
+  client.set("foo", serialized, None, None, false).await?;
   // deserialize as a json value
   let person_json: Value = client.get("foo").await?;
   let deserialized: Person = serde_json::from_value(person_json)?;
@@ -47,6 +46,6 @@ async fn main() -> Result<(), RedisError> {
   let deserialized: Person = serde_json::from_str(&person_string)?;
   assert_eq!(person, deserialized);
 
-  let _ = client.quit().await;
+  client.quit().await?;
   Ok(())
 }

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mutable_key_type)]
+
 use bytes_utils::Str;
 use fred::{prelude::*, types::XReadResponse};
 use std::time::Duration;

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -16,8 +16,7 @@ async fn main() {
         config.password = Some("bar".into());
       })
       .build()?;
-    client.connect();
-    client.wait_for_connect().await?;
+    client.init().await?;
 
     // initialize the stream first
     client.del("foo").await?;
@@ -53,8 +52,7 @@ async fn main() {
         config.password = Some("bar".into());
       })
       .build()?;
-    client.connect();
-    client.wait_for_connect().await?;
+    client.init().await?;
 
     // add values in groups of 2. this should create the following stream contents:
     // [{"field1":"a","field2":"b"}, {"field1":"c","field2":"d"}, {"field1":"e","field2":"f"}, ...]
@@ -74,9 +72,7 @@ async fn main() {
     Ok::<_, RedisError>(())
   });
 
-  futures::future::try_join_all([writer_task, reader_task])
-    .await
-    .expect("Error:");
+  futures::future::try_join_all([writer_task, reader_task]).await.unwrap();
 }
 
 // example output:

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -39,11 +39,7 @@ async fn main() -> Result<(), RedisError> {
     ..RedisConfig::default()
   };
   let client = Builder::from_config(config).build()?;
-
-  let _ = client.connect();
-  if let Err(error) = client.wait_for_connect().await {
-    panic!("Client failed to connect with error: {:?}", error);
-  }
+  client.init().await?;
 
   // ...
 

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -6,8 +6,7 @@ use fred::prelude::*;
 #[tokio::main]
 async fn main() -> Result<(), RedisError> {
   let client = RedisClient::default();
-  let _ = client.connect();
-  client.wait_for_connect().await?;
+  client.init().await?;
 
   let trx = client.multi();
   let result: RedisValue = trx.get("foo").await?;

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -8,6 +8,7 @@ async fn main() -> Result<(), RedisError> {
   let client = RedisClient::default();
   client.init().await?;
 
+  // transactions are buffered in memory before calling `exec`
   let trx = client.multi();
   let result: RedisValue = trx.get("foo").await?;
   assert!(result.is_queued());
@@ -16,6 +17,8 @@ async fn main() -> Result<(), RedisError> {
   let result: RedisValue = trx.get("foo").await?;
   assert!(result.is_queued());
 
+  // automatically send `WATCH ...` before `MULTI`
+  trx.watch_before(vec!["foo", "bar"]);
   let values: (Option<String>, (), String) = trx.exec(true).await?;
   println!("Transaction results: {:?}", values);
 

--- a/src/clients/options.rs
+++ b/src/clients/options.rs
@@ -16,8 +16,7 @@ use std::{fmt, ops::Deref, sync::Arc};
 /// # use std::time::Duration;
 /// async fn example() -> Result<(), RedisError> {
 ///   let client = RedisClient::default();
-///   let _ = client.connect();
-///   let _ = client.wait_for_connect().await?;
+///   client.init().await?;
 ///
 ///   let options = Options {
 ///     max_redirections: Some(3),

--- a/src/clients/pool.rs
+++ b/src/clients/pool.rs
@@ -6,7 +6,10 @@ use crate::{
   types::{ConnectHandle, ConnectionConfig, PerformanceConfig, ReconnectPolicy, RedisConfig, Server},
   utils,
 };
-use futures::future::{join_all, try_join_all};
+use futures::{
+  future::{join_all, try_join_all},
+  StreamExt,
+};
 use std::{
   fmt,
   sync::{
@@ -211,6 +214,8 @@ impl ClientLike for RedisPool {
   ///
   /// See [connect_pool](crate::clients::RedisPool::connect_pool) for a variation of this function that separates the
   /// connection tasks.
+  ///
+  /// See [init](Self::init) for an alternative shorthand.
   fn connect(&self) -> ConnectHandle {
     let clients = self.inner.clients.clone();
     tokio::spawn(async move {
@@ -237,6 +242,53 @@ impl ClientLike for RedisPool {
     let _ = try_join_all(self.inner.clients.iter().map(|c| c.wait_for_connect())).await?;
 
     Ok(())
+  }
+
+  /// Initialize a new routing and connection task for each client and wait for them to connect successfully.
+  ///
+  /// The returned [ConnectHandle](crate::types::ConnectHandle) refers to the task that drives the routing and
+  /// connection layer for each client via [join](https://docs.rs/futures/latest/futures/macro.join.html). It will not finish until the max reconnection count is reached.
+  ///
+  /// Callers can also use [connect](Self::connect) and [wait_for_connect](Self::wait_for_connect) separately if
+  /// needed.
+  ///
+  /// ```rust
+  /// use fred::prelude::*;
+  ///
+  /// #[tokio::main]
+  /// async fn main() -> Result<(), RedisError> {
+  ///   let pool = Builder::default_centralized().build_pool(5)?;
+  ///   let connection_task = pool.init().await?;
+  ///
+  ///   // ...
+  ///
+  ///   pool.quit().await?;
+  ///   connection_task.await?
+  /// }
+  /// ```
+  async fn init(&self) -> RedisResult<ConnectHandle> {
+    let rxs: Vec<_> = self
+      .inner
+      .clients
+      .iter()
+      .map(|c| c.inner.notifications.connect.load().subscribe().recv())
+      .collect();
+
+    let connect_task = self.connect();
+    let init_err = futures::future::join_all(rxs)
+      .await
+      .into_iter()
+      .find_map(|r| r.map_err(RedisError::from).and_then(|r| r).err());
+
+    if let Some(err) = init_err {
+      for client in self.inner.clients.iter() {
+        utils::reset_router_task(client.inner());
+      }
+
+      Err(err)
+    } else {
+      Ok(connect_task)
+    }
   }
 
   /// Close the connection to the Redis server for each client. The returned future resolves when the command has been

--- a/src/clients/pubsub.rs
+++ b/src/clients/pubsub.rs
@@ -30,13 +30,12 @@ type ChannelSet = Arc<RwLock<BTreeSet<Str>>>;
 ///
 /// async fn example() -> Result<(), RedisError> {
 ///   let subscriber = Builder::default_centralized().build_subscriber_client()?;
-///   let _ = subscriber.connect();
-///   subscriber.wait_for_connect().await?;
+///   subscriber.init().await?;
 ///
 ///   // spawn a task that will re-subscribe to channels and patterns after reconnecting
 ///   let _ = subscriber.manage_subscriptions();
 ///
-///   let mut message_rx = subscriber.on_message();
+///   let mut message_rx = subscriber.message_rx();
 ///   let jh = tokio::spawn(async move {
 ///     while let Ok(message) = message_rx.recv().await {
 ///       println!("Recv message {:?} on channel {}", message.value, message.channel);

--- a/src/commands/interfaces/server.rs
+++ b/src/commands/interfaces/server.rs
@@ -41,8 +41,6 @@ pub trait AuthInterface: ClientLike {
 #[async_trait]
 pub trait HeartbeatInterface: ClientLike {
   /// Return a future that will ping the server on an interval.
-  ///
-  /// When running against a cluster this will ping a random node on each interval.
   #[allow(unreachable_code)]
   async fn enable_heartbeat(&self, interval: Duration, break_on_error: bool) -> RedisResult<()> {
     let _self = self.clone();

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -228,27 +228,17 @@ pub trait ClientLike: Clone + Send + Sized {
   /// Connect to the Redis server.
   ///
   /// This function returns a `JoinHandle` to a task that drives the connection. It will not resolve until the
-  /// connection closes, and if a reconnection policy with unlimited attempts is provided then the `JoinHandle` will
+  /// connection closes, of if a reconnection policy with unlimited attempts is provided then it will
   /// run until `QUIT` is called.
   ///
   /// **Calling this function more than once will drop all state associated with the previous connection(s).** Any
   /// pending commands on the old connection(s) will either finish or timeout, but they will not be retried on the
   /// new connection(s).
+  ///
+  /// See [init](Self::init) for an alternative shorthand.
   fn connect(&self) -> ConnectHandle {
     let inner = self.inner().clone();
-    {
-      let _guard = inner._lock.lock();
-
-      if !inner.has_command_rx() {
-        _trace!(inner, "Resetting command channel before connecting.");
-        // another connection task is running. this will let the command channel drain, then it'll drop everything on
-        // the old connection/router interface.
-        let (tx, rx) = unbounded_channel();
-        let old_command_tx = inner.swap_command_tx(tx);
-        inner.store_command_rx(rx, true);
-        utils::close_router_channel(&inner, old_command_tx);
-      }
-    }
+    utils::reset_router_task(&inner);
 
     tokio::spawn(async move {
       utils::clear_backchannel_state(&inner).await;
@@ -285,6 +275,42 @@ pub trait ClientLike: Clone + Send + Sized {
     } else {
       self.inner().notifications.connect.load().subscribe().recv().await?
     }
+  }
+
+  /// Initialize a new routing and connection task and wait for it to connect successfully.
+  ///
+  /// The returned [ConnectHandle](crate::types::ConnectHandle) refers to the task that drives the routing and
+  /// connection layer. It will not finish until the max reconnection count is reached.
+  ///
+  /// Callers can also use [connect](Self::connect) and [wait_for_connect](Self::wait_for_connect) separately if
+  /// needed.
+  ///
+  /// ```rust
+  /// use fred::prelude::*;
+  ///
+  /// #[tokio::main]
+  /// async fn main() -> Result<(), RedisError> {
+  ///   let client = RedisClient::default();
+  ///   let connection_task = client.init().await?;
+  ///
+  ///   // ...
+  ///
+  ///   client.quit().await?;
+  ///   connection_task.await?
+  /// }
+  /// ```
+  async fn init(&self) -> RedisResult<ConnectHandle> {
+    let mut rx = { self.inner().notifications.connect.load().subscribe() };
+    let task = self.connect();
+
+    let result = rx.recv().await;
+    if result.map(|r| r.is_err()).unwrap_or(result.is_err()) {
+      // the initial connection failed so we should gracefully close the routing task
+      utils::reset_router_task(self.inner());
+    }
+
+    result??;
+    Ok(task)
   }
 
   /// Close the connection to the Redis server. The returned future resolves when the command has been written to the

--- a/src/modules/mocks.rs
+++ b/src/modules/mocks.rs
@@ -71,6 +71,7 @@ pub trait Mocks: Debug + Send + Sync + 'static {
 /// An implementation of a mocking layer that returns the provided arguments to the caller.
 ///
 /// ```rust no_run
+/// # use fred::prelude::*;
 /// #[tokio::test]
 /// async fn should_use_echo_mock() {
 ///   let config = RedisConfig {
@@ -78,8 +79,7 @@ pub trait Mocks: Debug + Send + Sync + 'static {
 ///     ..Default::default()
 ///   };
 ///   let client = Builder::from_config(config).build().unwrap();
-///   let _ = client.connect();
-///   let _ = client.wait_for_connect().await.expect("Failed to connect");
+///   client.init().await.expect("Failed to connect");
 ///
 ///   let actual: Vec<RedisValue> = client
 ///     .set(
@@ -124,8 +124,7 @@ impl Mocks for Echo {
 ///     ..Default::default()
 ///   };
 ///   let client = Builder::from_config(config).build().unwrap();
-///   let _ = client.connect();
-///   let _ = client.wait_for_connect().await.expect("Failed to connect");
+///   client.init().await.expect("Failed to connect");
 ///
 ///   let actual: String = client
 ///       .set("foo", "bar", None, None, false)
@@ -229,8 +228,7 @@ impl Mocks for SimpleMap {
 ///     ..Default::default()
 ///   };
 ///   let client = Builder::from_config(config).build().unwrap();
-///   let _ = client.connect();
-///   let _ = client.wait_for_connect().await.expect("Failed to connect");
+///   client.init().await.expect("Failed to connect");
 ///
 ///   let actual: String = client
 ///     .set("foo", "bar", None, None, false)

--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -814,7 +814,7 @@ impl RedisTransport {
 
     utils::apply_timeout(
       async {
-        if inner.config.password.is_some() {
+        if inner.config.password.is_some() || inner.config.version == RespVersion::RESP3 {
           self.switch_protocols_and_authenticate(inner).await?;
         } else {
           self.ping(inner).await?;

--- a/src/router/utils.rs
+++ b/src/router/utils.rs
@@ -400,6 +400,15 @@ pub async fn send_asking_with_policy(
   Ok(())
 }
 
+#[cfg(feature = "replicas")]
+async fn sync_cluster_replicas(inner: &Arc<RedisClientInner>, router: &mut Router) -> Result<(), RedisError> {
+  if inner.config.server.is_clustered() {
+    router.sync_cluster().await
+  } else {
+    router.sync_replicas().await
+  }
+}
+
 /// Repeatedly try to sync the cluster state, reconnecting as needed until the max reconnection attempts is reached.
 #[cfg(feature = "replicas")]
 pub async fn sync_replicas_with_policy(inner: &Arc<RedisClientInner>, router: &mut Router) -> Result<(), RedisError> {
@@ -411,7 +420,7 @@ pub async fn sync_replicas_with_policy(inner: &Arc<RedisClientInner>, router: &m
       let _ = inner.wait_with_interrupt(delay).await?;
     }
 
-    if let Err(e) = router.sync_replicas().await {
+    if let Err(e) = sync_cluster_replicas(inner, router).await {
       _warn!(inner, "Error syncing replicas: {:?}", e);
 
       if e.should_not_reconnect() {

--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -1195,8 +1195,7 @@ impl From<SentinelConfig> for RedisConfig {
 ///   };
 ///
 ///   let client = RedisClient::default();
-///   let _ = client.connect();
-///   let _ = client.wait_for_connect().await?;
+///   client.init().await?;
 ///   let _: () = client.with_options(&options).get("foo").await?;
 ///
 ///   Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,6 @@ use crate::{
     utils as protocol_utils,
   },
   types::*,
-  utils,
 };
 use arc_swap::ArcSwap;
 use bytes::Bytes;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -330,7 +330,7 @@ pub fn reset_router_task(inner: &Arc<RedisClientInner>) {
     let (tx, rx) = unbounded_channel();
     let old_command_tx = inner.swap_command_tx(tx);
     inner.store_command_rx(rx, true);
-    close_router_channel(&inner, old_command_tx);
+    close_router_channel(inner, old_command_tx);
   }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,7 @@ use crate::{
     utils as protocol_utils,
   },
   types::*,
+  utils,
 };
 use arc_swap::ArcSwap;
 use bytes::Bytes;
@@ -52,6 +53,7 @@ use parking_lot::Mutex;
 use std::mem;
 #[cfg(feature = "unix-sockets")]
 use std::path::Path;
+use tokio::sync::mpsc::unbounded_channel;
 #[cfg(any(feature = "full-tracing", feature = "partial-tracing"))]
 use tracing_futures::Instrument;
 
@@ -315,6 +317,21 @@ where
     }
   } else {
     ft.await.map_err(|e| e.into())
+  }
+}
+
+/// Disconnect any state shared with the last router task spawned by the client.
+pub fn reset_router_task(inner: &Arc<RedisClientInner>) {
+  let _guard = inner._lock.lock();
+
+  if !inner.has_command_rx() {
+    _trace!(inner, "Resetting command channel before connecting.");
+    // another connection task is running. this will let the command channel drain, then it'll drop everything on
+    // the old connection/router interface.
+    let (tx, rx) = unbounded_channel();
+    let old_command_tx = inner.swap_command_tx(tx);
+    inner.store_command_rx(rx, true);
+    close_router_channel(&inner, old_command_tx);
   }
 }
 
@@ -820,8 +837,7 @@ pub async fn clear_backchannel_state(inner: &Arc<RedisClientInner>) {
 }
 
 /// Send QUIT to the servers and clean up the old router task's state.
-pub fn close_router_channel(inner: &Arc<RedisClientInner>, command_tx: Arc<CommandSender>) {
-  set_client_state(&inner.state, ClientState::Disconnecting);
+fn close_router_channel(inner: &Arc<RedisClientInner>, command_tx: Arc<CommandSender>) {
   inner.notifications.broadcast_close();
   inner.reset_server_state();
 

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -41,6 +41,10 @@ mod other {
   centralized_test!(other, should_fail_with_bad_host_via_init_interface);
   centralized_test!(other, should_connect_correctly_via_wait_interface);
   centralized_test!(other, should_fail_with_bad_host_via_wait_interface);
+  centralized_test!(other, pool_should_connect_correctly_via_init_interface);
+  centralized_test!(other, pool_should_fail_with_bad_host_via_init_interface);
+  centralized_test!(other, pool_should_connect_correctly_via_wait_interface);
+  centralized_test!(other, pool_should_fail_with_bad_host_via_wait_interface);
 
   #[cfg(feature = "metrics")]
   centralized_test!(other, should_track_size_stats);

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -37,6 +37,11 @@ mod multi {
 }
 
 mod other {
+  centralized_test!(other, should_connect_correctly_via_init_interface);
+  centralized_test!(other, should_fail_with_bad_host_via_init_interface);
+  centralized_test!(other, should_connect_correctly_via_wait_interface);
+  centralized_test!(other, should_fail_with_bad_host_via_wait_interface);
+
   #[cfg(feature = "metrics")]
   centralized_test!(other, should_track_size_stats);
 

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -39,6 +39,10 @@ mod multi {
 }
 
 mod other {
+  cluster_test!(other, should_connect_correctly_via_init_interface);
+  cluster_test!(other, should_fail_with_bad_host_via_init_interface);
+  cluster_test!(other, should_connect_correctly_via_wait_interface);
+  cluster_test!(other, should_fail_with_bad_host_via_wait_interface);
 
   #[cfg(feature = "metrics")]
   cluster_test!(other, should_track_size_stats);

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -43,6 +43,10 @@ mod other {
   cluster_test!(other, should_fail_with_bad_host_via_init_interface);
   cluster_test!(other, should_connect_correctly_via_wait_interface);
   cluster_test!(other, should_fail_with_bad_host_via_wait_interface);
+  cluster_test!(other, pool_should_connect_correctly_via_init_interface);
+  cluster_test!(other, pool_should_fail_with_bad_host_via_init_interface);
+  cluster_test!(other, pool_should_connect_correctly_via_wait_interface);
+  cluster_test!(other, pool_should_fail_with_bad_host_via_wait_interface);
 
   #[cfg(feature = "metrics")]
   cluster_test!(other, should_track_size_stats);

--- a/tests/integration/other/mod.rs
+++ b/tests/integration/other/mod.rs
@@ -658,3 +658,31 @@ pub async fn should_use_resp2_codec_example(_: RedisClient, config: RedisConfig)
 
   Ok(())
 }
+
+pub async fn should_connect_correctly_via_init_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  unimplemented!()
+}
+
+pub async fn should_fail_with_bad_host_via_init_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  unimplemented!()
+}
+
+pub async fn should_connect_correctly_via_wait_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  unimplemented!()
+}
+
+pub async fn should_fail_with_bad_host_via_wait_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  unimplemented!()
+}

--- a/tests/integration/other/mod.rs
+++ b/tests/integration/other/mod.rs
@@ -46,6 +46,7 @@ use std::net::{IpAddr, SocketAddr};
 #[cfg(feature = "dns")]
 use trust_dns_resolver::{config::*, TokioAsyncResolver};
 
+use fred::types::Builder;
 #[cfg(feature = "codec")]
 use futures::{SinkExt, StreamExt};
 #[cfg(feature = "codec")]
@@ -659,30 +660,106 @@ pub async fn should_use_resp2_codec_example(_: RedisClient, config: RedisConfig)
   Ok(())
 }
 
+pub async fn pool_should_connect_correctly_via_init_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  let pool = Builder::from_config(config).build_pool(5)?;
+  let task = pool.init().await?;
+
+  pool.ping().await?;
+  pool.quit().await?;
+  task.await??;
+  Ok(())
+}
+
+pub async fn pool_should_fail_with_bad_host_via_init_interface(
+  _: RedisClient,
+  mut config: RedisConfig,
+) -> Result<(), RedisError> {
+  config.fail_fast = true;
+  config.server = ServerConfig::new_centralized("incorrecthost", 1234);
+  let pool = Builder::from_config(config).build_pool(5)?;
+  assert!(pool.init().await.is_err());
+  Ok(())
+}
+
+pub async fn pool_should_connect_correctly_via_wait_interface(
+  _: RedisClient,
+  config: RedisConfig,
+) -> Result<(), RedisError> {
+  let pool = Builder::from_config(config).build_pool(5)?;
+  let task = pool.connect();
+  pool.wait_for_connect().await?;
+
+  pool.ping().await?;
+  pool.quit().await?;
+  task.await??;
+  Ok(())
+}
+
+pub async fn pool_should_fail_with_bad_host_via_wait_interface(
+  _: RedisClient,
+  mut config: RedisConfig,
+) -> Result<(), RedisError> {
+  config.fail_fast = true;
+  config.server = ServerConfig::new_centralized("incorrecthost", 1234);
+  let pool = Builder::from_config(config).build_pool(5)?;
+  let task = pool.connect();
+  assert!(pool.wait_for_connect().await.is_err());
+
+  let _ = task.await;
+  Ok(())
+}
+
 pub async fn should_connect_correctly_via_init_interface(
   _: RedisClient,
   config: RedisConfig,
 ) -> Result<(), RedisError> {
-  unimplemented!()
+  let client = Builder::from_config(config).build()?;
+  let task = client.init().await?;
+
+  client.ping().await?;
+  client.quit().await?;
+  task.await??;
+  Ok(())
 }
 
 pub async fn should_fail_with_bad_host_via_init_interface(
   _: RedisClient,
-  config: RedisConfig,
+  mut config: RedisConfig,
 ) -> Result<(), RedisError> {
-  unimplemented!()
+  config.fail_fast = true;
+  config.server = ServerConfig::new_centralized("incorrecthost", 1234);
+  let client = Builder::from_config(config).build()?;
+  assert!(client.init().await.is_err());
+  Ok(())
 }
 
 pub async fn should_connect_correctly_via_wait_interface(
   _: RedisClient,
   config: RedisConfig,
 ) -> Result<(), RedisError> {
-  unimplemented!()
+  let client = Builder::from_config(config).build()?;
+  let task = client.connect();
+  client.wait_for_connect().await?;
+
+  client.ping().await?;
+  client.quit().await?;
+  task.await??;
+  Ok(())
 }
 
 pub async fn should_fail_with_bad_host_via_wait_interface(
   _: RedisClient,
-  config: RedisConfig,
+  mut config: RedisConfig,
 ) -> Result<(), RedisError> {
-  unimplemented!()
+  config.fail_fast = true;
+  config.server = ServerConfig::new_centralized("incorrecthost", 1234);
+  let client = Builder::from_config(config).build()?;
+  let task = client.connect();
+  assert!(client.wait_for_connect().await.is_err());
+
+  let _ = task.await;
+  Ok(())
 }


### PR DESCRIPTION
* Add a shorthand `init` interface.
* Fix cluster replica failover with unresponsive connections (https://github.com/aembke/fred.rs/issues/208).
* Fix RESP3 connection init when used without a password (https://github.com/aembke/fred.rs/issues/207).