### PR TITLE
8.0.1

### DIFF
--- a/bin/inf_loop/Cargo.toml
+++ b/bin/inf_loop/Cargo.toml
@@ -11,7 +11,7 @@ debug = true
 [dependencies]
 clap = { version = "2.33", features = ["yaml"] }
 log = "0.4"
-pretty_env_logger = "0.4"
+pretty_env_logger = "0.5"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 rand = "0.8"
@@ -22,5 +22,4 @@ path = "/fred"
 default-features = false
 
 [features]
-default = ["fred/network-logs", "fred/debug-ids"]
-replicas = ["fred/replicas"]
+default = ["fred/network-logs", "fred/debug-ids", "fred/replicas"]

--- a/bin/inf_loop/cli.yml
+++ b/bin/inf_loop/cli.yml
@@ -5,7 +5,11 @@ about: Run a script that sends `INCR foo` on an interval forever, with an infini
 args:
   - cluster:
       long: cluster
-      help: Whether or not to use a clustered deployment.
+      help: Whether to use a clustered deployment.
+      takes_value: false
+  - replicas:
+      long: replicas
+      help: Whether to use `GET` with replicas instead of `INCR` with primary nodes.
       takes_value: false
   - host:
       short: h

--- a/bin/inf_loop/docker-compose.yml
+++ b/bin/inf_loop/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         REDIS_VERSION: "${REDIS_VERSION}"
     networks:
       - fred-tests
-    entrypoint: "cargo run --release --features \"replicas\" -- ${TEST_ARGV}"
+    entrypoint: "cargo run --release -- ${TEST_ARGV}"
     environment:
       RUST_LOG: "${RUST_LOG}"
       REDIS_VERSION: "${REDIS_VERSION}"

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -531,6 +531,21 @@ impl ClusterRouting {
   pub fn random_node(&self) -> Option<&Server> {
     self.random_slot().map(|slot| &slot.primary)
   }
+
+  /// Print the contents of the routing table as a human-readable map.
+  pub fn pretty(&self) -> BTreeMap<Server, (Vec<(u16, u16)>, BTreeSet<Server>)> {
+    let mut out = BTreeMap::new();
+    for slot_range in self.data.iter() {
+      let entry = out
+        .entry(slot_range.primary.clone())
+        .or_insert((Vec::new(), BTreeSet::new()));
+      entry.0.push((slot_range.start, slot_range.end));
+      #[cfg(feature = "replicas")]
+      entry.1.extend(slot_range.replicas.iter().cloned());
+    }
+
+    out
+  }
 }
 
 /// A trait that can be used to override DNS resolution logic.

--- a/src/router/clustered.rs
+++ b/src/router/clustered.rs
@@ -645,6 +645,7 @@ pub async fn sync(
   if let Connections::Clustered { cache, writers } = connections {
     // send `CLUSTER SLOTS` to any of the cluster nodes via a backchannel
     let state = cluster_slots_backchannel(inner, Some(&*cache)).await?;
+    _debug!(inner, "Cluster routing state: {:?}", state.pretty());
     // update the cached routing table
     inner
       .server_state

--- a/src/router/utils.rs
+++ b/src/router/utils.rs
@@ -246,7 +246,8 @@ pub async fn reconnect_once(inner: &Arc<RedisClientInner>, router: &mut Router) 
     inner.notifications.broadcast_error(e.clone());
     Err(e)
   } else {
-    if let Err(e) = router.sync_replicas().await {
+    #[cfg(feature = "replicas")]
+    if let Err(e) = router.refresh_replica_routing().await {
       _warn!(inner, "Error syncing replicas: {:?}", e);
       if !inner.ignore_replica_reconnect_errors() {
         client_utils::set_client_state(&inner.state, ClientState::Disconnected);


### PR DESCRIPTION
* Add a shorthand `init` interface.
* Fix cluster replica failover with unresponsive connections.
* Fix RESP3 connection init when used without a password.