### PR TITLE
fix(trace): fix the wrong type name

### DIFF
--- a/src/trace/enabled.rs
+++ b/src/trace/enabled.rs
@@ -107,7 +107,7 @@ pub fn create_pubsub_span(inner: &Arc<RedisClientInner>, frame: &Resp3Frame) -> 
 }
 
 #[cfg(not(feature = "full-tracing"))]
-pub fn create_pubsub_span(_inner: &Arc<RedisClientInner>, _frame: &Frame) -> Option<FakeSpan> {
+pub fn create_pubsub_span(_inner: &Arc<RedisClientInner>, _frame: &Resp3Frame) -> Option<FakeSpan> {
   Some(FakeSpan {})
 }
 


### PR DESCRIPTION
After updated to latest version(v9.0.0).
```toml
fred = { version = "9.0", features = ["partial-tracing", "serde-json"] }
```

Found this error:
![image](https://github.com/aembke/fred.rs/assets/24818903/59c1d0f2-61ef-480b-9fbe-4f039870a2bc)
