### PR TITLE
9.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.0.3
+
+* Fix `bytes_utils` min version
+* Fix rustls reexports with `enable-rustls-ring`.
+
 ## 9.0.2
 
 * Add `enable-rustls-ring` feature flag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fred"
-version = "9.0.2"
+version = "9.0.3"
 authors = ["Alec Embke <aembke@gmail.com>"]
 edition = "2021"
 description = "An async Redis client built on Tokio."
@@ -22,7 +22,7 @@ arc-swap = "1.7"
 tokio = { version = "1.34", features = ["net", "sync", "rt", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.6"
-bytes-utils = "0.1"
+bytes-utils = "0.1.3"
 futures = { version = "0.3", features = ["std"] }
 parking_lot = "0.12"
 redis-protocol = { version = "5.0.1", features = ["resp2", "resp3", "bytes"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,11 @@ pub extern crate bytes_utils;
 #[cfg(feature = "enable-native-tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "enable-native-tls")))]
 pub extern crate native_tls;
-#[cfg(feature = "enable-rustls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "enable-rustls")))]
+#[cfg(any(feature = "enable-rustls", feature = "enable-rustls-ring"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "enable-rustls", feature = "enable-rustls-ring"))))]
 pub extern crate rustls;
-#[cfg(feature = "enable-rustls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "enable-rustls")))]
+#[cfg(any(feature = "enable-rustls", feature = "enable-rustls-ring"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "enable-rustls", feature = "enable-rustls-ring"))))]
 pub extern crate rustls_native_certs;
 #[cfg(feature = "serde-json")]
 pub extern crate serde_json;


### PR DESCRIPTION
* Fix `bytes_utils` min version
* Fix rustls reexports with `enable-rustls-ring`.