### PR TITLE
log error if on_error listener is not provided

### DIFF
--- a/src/modules/inner.rs
+++ b/src/modules/inner.rs
@@ -24,7 +24,7 @@ use std::{
 };
 use tokio::{
   sync::{
-    broadcast::{self, Sender as BroadcastSender},
+    broadcast::{self, Sender as BroadcastSender, error::SendError as BroadcastSendError},
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     RwLock as AsyncRwLock,
   },
@@ -100,8 +100,8 @@ impl Notifications {
   }
 
   pub fn broadcast_error(&self, error: RedisError) {
-    if let Err(_) = self.errors.load().send(error) {
-      debug!("{}: No `on_error` listener.", self.id);
+    if let Err(BroadcastSendError(err)) = self.errors.load().send(error) {
+      debug!("{}: No `on_error` listener. The error was: {err:?}", self.id);
     }
   }
 


### PR DESCRIPTION
Hello.

Not sure if this change makes sense, but i believe it can be useful for development/debugging experience.

It's quite easy to provide no on_error handler, but if with that you use `.connect()` instead of `.init()` with some wrong connection configuration you'll see no errors in the log, which can be somewhat confusing.

To see this in action try running this example:
<details>
<summary>basic.rs + logging + changed connection url + connect()</summary>

```rust
use fred::prelude::*;

#[tokio::main]
async fn main() -> Result<(), RedisError> {
  pretty_env_logger::init();

  // create a config from a URL
  let config = RedisConfig::from_url("redis://user:doesntexist@127.0.0.1:6379/0")?;
  // see the `Builder` interface for more information
  let client = Builder::from_config(config).build()?;
  // callers can manage the tokio task driving the connections
  let _connection_task = client.connect().await?;
  // convert response types to most common rust types
  let foo: Option<String> = client.get("foo").await?;
  println!("Foo: {:?}", foo);

  client
    .set("foo", "bar", Some(Expiration::EX(1)), Some(SetOptions::NX), false)
    .await?;

  // or use turbofish. the first type is always the response type.
  println!("Foo: {:?}", client.get::<Option<String>, _>("foo").await?);

  client.quit().await?;
  Ok(())
}
```

</details>

on current main it leads to this log excerpt:
```
 DEBUG fred::protocol::connection > fred-TbWotneuIp: Creating TCP connection to 127.0.0.1 at 127.0.0.1:6379
 DEBUG fred::modules::inner       > fred-TbWotneuIp: No `on_connect` listeners.
 DEBUG fred::modules::inner       > fred-TbWotneuIp: No `on_error` listener.
 DEBUG fred::modules::inner       > fred-TbWotneuIp: No `on_connect` listeners.
```

and with this change it becomes
```
 DEBUG fred::modules::inner       > fred-oQONQKELmH: No `on_error` listener. The error was: Redis Error - kind: Auth, details: NOAUTH Authentication required.
```

