### PR TITLE
fix!: Remove infinitely recursing `From` impl

### DIFF
--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -1508,12 +1508,6 @@ impl From<Bytes> for RedisValue {
   }
 }
 
-impl From<&Box<[u8]>> for RedisValue {
-  fn from(b: &Box<[u8]>) -> Self {
-    b.into()
-  }
-}
-
 impl From<Box<[u8]>> for RedisValue {
   fn from(b: Box<[u8]>) -> Self {
     RedisValue::Bytes(b.into())


### PR DESCRIPTION
Remove the infinitely recursing implementation of `From<&Box<[u8]>>` for `RedisValue`.

In practice, this impl would cause infinite recursion, so it was probably never used. Since this is a change to a public API, it is technically a breaking change.

To convert a `&Box<[u8]>` to a `RedisValue`, users can clone the box.
