### PR TITLE
fix: do not ignore invalid client config to cluster on reconn

### DIFF
--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -98,7 +98,15 @@ pub fn pretty_error(resp: &str) -> RedisError {
 
     match parts.next().unwrap_or("") {
       "" => RedisErrorKind::Unknown,
-      "ERR" => RedisErrorKind::Unknown,
+      "ERR" => {
+        if resp.contains("instance has cluster support disabled") {
+          // Cluster client connecting to non-cluster server.
+          // Returning Config to signal no reconnect will help.
+          RedisErrorKind::Config
+        } else {
+          RedisErrorKind::Unknown
+        }
+      },
       "WRONGTYPE" => RedisErrorKind::InvalidArgument,
       "NOAUTH" | "WRONGPASS" => RedisErrorKind::Auth,
       "MOVED" | "ASK" | "CLUSTERDOWN" => RedisErrorKind::Cluster,

--- a/src/router/utils.rs
+++ b/src/router/utils.rs
@@ -278,6 +278,10 @@ pub async fn reconnect_with_policy(inner: &Arc<RedisClientInner>, router: &mut R
     }
 
     if let Err(e) = reconnect_once(inner, router).await {
+      if e.should_not_reconnect() {
+        return Err(e);
+      }
+
       delay = match next_reconnection_delay(inner) {
         Ok(delay) => delay,
         Err(_) => return Err(e),

--- a/tests/integration/clustered.rs
+++ b/tests/integration/clustered.rs
@@ -48,6 +48,7 @@ mod other {
   cluster_test!(other, pool_should_fail_with_bad_host_via_init_interface);
   cluster_test!(other, pool_should_connect_correctly_via_wait_interface);
   cluster_test!(other, pool_should_fail_with_bad_host_via_wait_interface);
+  cluster_test!(other, should_fail_on_centralized_connect);
 
   #[cfg(feature = "metrics")]
   cluster_test!(other, should_track_size_stats);


### PR DESCRIPTION
If connecting with the wrong client to the cluster it may inf retry when it should not.