### PR TITLE
implement 'SETNX' command

### DIFF
--- a/src/commands/impls/keys.rs
+++ b/src/commands/impls/keys.rs
@@ -58,6 +58,10 @@ pub async fn set<C: ClientLike>(
   protocol_utils::frame_to_results(frame)
 }
 
+pub async fn setnx<C: ClientLike>(client: &C, key: RedisKey, value: RedisValue) -> Result<RedisValue, RedisError> {
+  args_value_cmd(client, RedisCommandKind::Setnx, vec![key.into(), value]).await
+}
+
 pub async fn del<C: ClientLike>(client: &C, keys: MultipleKeys) -> Result<RedisValue, RedisError> {
   check_empty_keys(&keys)?;
 

--- a/src/commands/interfaces/keys.rs
+++ b/src/commands/interfaces/keys.rs
@@ -131,6 +131,25 @@ pub trait KeysInterface: ClientLike + Sized {
     }
   }
 
+  /// Sets `key` to `value` if `key` does not exist.
+  ///
+  /// Note: the command is regarded as deprecated since Redis 2.6.12.
+  ///
+  /// <https://redis.io/commands/setnx>
+  fn setnx<R, K, V>(&self, key: K, value: V) -> impl Future<Output = RedisResult<R>> + Send
+  where
+    R: FromRedis,
+    K: Into<RedisKey> + Send,
+    V: TryInto<RedisValue> + Send,
+    V::Error: Into<RedisError> + Send,
+  {
+    async move {
+      into!(key);
+      try_into!(value);
+      commands::keys::setnx(self, key, value).await?.convert()
+    }
+  }
+
   /// Read a value from the server.
   ///
   /// <https://redis.io/commands/get>

--- a/tests/integration/centralized.rs
+++ b/tests/integration/centralized.rs
@@ -4,6 +4,7 @@ mod keys {
   centralized_test!(keys, should_set_and_get_a_value);
   centralized_test!(keys, should_set_and_del_a_value);
   centralized_test!(keys, should_set_with_get_argument);
+  centralized_test!(keys, should_setnx_value);
   centralized_test!(keys, should_incr_and_decr_a_value);
   centralized_test!(keys, should_incr_by_float);
   centralized_test!(keys, should_mset_a_non_empty_map);

--- a/tests/integration/keys/mod.rs
+++ b/tests/integration/keys/mod.rs
@@ -347,3 +347,19 @@ pub async fn should_pexpire_key(client: RedisClient, _: RedisConfig) -> Result<(
   assert_eq!(client.get::<Option<String>, _>("foo").await?, None);
   Ok(())
 }
+
+pub async fn should_setnx_value(client: RedisClient, _: RedisConfig) -> Result<(), RedisError> {
+  let value_set: i64 = client.setnx("foo", 123456).await?;
+  assert_eq!(value_set, 1);
+
+  let remote_value: i64 = client.get("foo").await?;
+  assert_eq!(remote_value, 123456);
+
+  let value_set: i64 = client.setnx("foo", 654321).await?;
+  assert_eq!(value_set, 0);
+
+  let remote_value: i64 = client.get("foo").await?;
+  assert_eq!(remote_value, 123456);
+
+  Ok(())
+}


### PR DESCRIPTION
Resolves #294 

Adding the [`SETNX`](https://redis.io/docs/latest/commands/setnx/) command to `KeysInterface`.