### PR TITLE
chore: bump rand to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ log = "0.4"
 native-tls = { version = "0.2", optional = true }
 nom = { version = "7.1", optional = true }
 parking_lot = "0.12"
-rand = "0.8"
+rand = "0.9"
 redis-protocol = { version = "6.0.0", features = ["resp2", "resp3", "bytes"] }
 rustls = { version = "0.23", optional = true, default-features = false }
 rustls-native-certs = { version = "0.8", optional = true }

--- a/bin/benchmark/src/utils.rs
+++ b/bin/benchmark/src/utils.rs
@@ -1,4 +1,4 @@
-use rand::{self, distributions::Alphanumeric, Rng};
+use rand::{self, distr::Alphanumeric, Rng};
 use std::{
   env,
   error::Error,
@@ -32,7 +32,7 @@ pub fn read_auth_env() -> (Option<String>, Option<String>) {
 }
 
 pub fn random_string(len: usize) -> String {
-  rand::thread_rng()
+  rand::rng()
     .sample_iter(&Alphanumeric)
     .take(len)
     .map(char::from)

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -605,7 +605,7 @@ impl ClusterRouting {
   /// Read a random primary node hash slot range from the cluster cache.
   pub fn random_slot(&self) -> Option<&SlotRange> {
     if !self.data.is_empty() {
-      let idx = rand::thread_rng().gen_range(0 .. self.data.len());
+      let idx = rand::rng().random_range(0 .. self.data.len());
       Some(&self.data[idx])
     } else {
       None

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use bytes_utils::Str;
 use float_cmp::approx_eq;
 use futures::{Future, TryFutureExt};
-use rand::{self, distributions::Alphanumeric, Rng};
+use rand::{self, distr::Alphanumeric, Rng};
 use redis_protocol::resp3::types::BytesFrame as Resp3Frame;
 use std::{collections::HashMap, convert::TryInto, f64, sync::atomic::Ordering, time::Duration};
 use url::Url;
@@ -151,7 +151,7 @@ pub fn incr_with_max(curr: u32, max: u32) -> Option<u32> {
 }
 
 pub fn random_string(len: usize) -> String {
-  rand::thread_rng()
+  rand::rng()
     .sample_iter(&Alphanumeric)
     .take(len)
     .map(char::from)
@@ -168,7 +168,7 @@ where
 
 #[cfg(feature = "transactions")]
 pub fn random_u64(max: u64) -> u64 {
-  rand::thread_rng().gen_range(0 .. max)
+  rand::rng().random_range(0 .. max)
 }
 
 pub fn read_bool_atomic(val: &AtomicBool) -> bool {
@@ -566,7 +566,7 @@ pub fn add_jitter(delay: u64, jitter: u32) -> u64 {
   if jitter == 0 {
     delay
   } else {
-    delay.saturating_add(rand::thread_rng().gen_range(0 .. jitter as u64))
+    delay.saturating_add(rand::rng().random_range(0 .. jitter as u64))
   }
 }
 

--- a/tests/integration/redisearch/mod.rs
+++ b/tests/integration/redisearch/mod.rs
@@ -17,7 +17,7 @@ use fred::{
   util::NONE,
 };
 use maplit::hashmap;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use redis_protocol::resp3::types::RespVersion;
 use std::{collections::HashMap, time::Duration};
 
@@ -206,7 +206,7 @@ pub async fn should_index_and_aggregate_timestamps(client: Client, _: Config) ->
     .await?;
 
   for idx in 0 .. 100 {
-    let rand: u64 = thread_rng().gen_range(0 .. 10000);
+    let rand: u64 = rng().random_range(0 .. 10000);
     let _: () = client
       .hset(format!("record:{}", idx), [
         ("timestamp", idx),


### PR DESCRIPTION
`rand` [0.9](https://rust-random.github.io/book/update-0.9.html) contains some function name changes to support the new reserved `gen` keyword. This PR bumps rand to 0.9 and updates the used functions to the new name