### PR TITLE
fix(doc): ReconnectPolicy::set_jitter

### DIFF
--- a/src/types/config.rs
+++ b/src/types/config.rs
@@ -168,7 +168,7 @@ impl ReconnectPolicy {
 
   /// Set the amount of jitter to add to each reconnect delay.
   ///
-  /// Default: 50 ms
+  /// Defaults to [`DEFAULT_JITTER_MS`].
   pub fn set_jitter(&mut self, jitter_ms: u32) {
     match self {
       ReconnectPolicy::Constant { ref mut jitter, .. } => {


### PR DESCRIPTION
Default is actually 100, but we should just refer user to the docs so they don't drift out of sync.