### PR TITLE
(feat) Streams: "_map" methods to return an Option for empty/null xread response

### DIFF
--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -28,7 +28,11 @@ async fn main() {
     let mut count = 0;
     loop {
       // call XREAD for new records in a loop, blocking up to 10 sec each time
-      let entry: XReadResponse<Str, Str, Str, Str> = client.xread_map(Some(1), Some(10_000), "foo", "$").await?;
+      // Note: _map return an Option in the result of an empty stream response.
+      let entry: XReadResponse<Str, Str, Str, Str> = client.xread_map(Some(1), Some(10_000), "foo", "$")
+        .await?
+        .expect("Expected Some found None."); 
+
       count += 1;
 
       for (key, records) in entry.into_iter() {

--- a/src/commands/interfaces/streams.rs
+++ b/src/commands/interfaces/streams.rs
@@ -384,6 +384,12 @@ pub trait StreamsInterface: ClientLike + Sized {
       let value = commands::streams::xread(self, count, block, keys, ids)
         .await?;
 
+      if let Value::Array(values) = &value {
+        if values.len() == 0 {
+          return Ok(None);
+        }
+      }
+
       if let Value::Null = value {
         return Ok(None);
       }
@@ -560,6 +566,12 @@ pub trait StreamsInterface: ClientLike + Sized {
       into!(group, consumer, keys, ids);
       let value = commands::streams::xreadgroup(self, group, consumer, count, block, noack, keys, ids)
         .await?;
+
+      if let Value::Array(values) = &value {
+        if values.len() == 0 {
+          return Ok(None);
+        }
+      }
 
       if let Value::Null = value {
         return Ok(None);

--- a/src/commands/interfaces/streams.rs
+++ b/src/commands/interfaces/streams.rs
@@ -556,13 +556,6 @@ pub trait StreamsInterface: ClientLike + Sized {
     K: Into<MultipleKeys> + Send,
     I: Into<MultipleIDs> + Send,
   {
-    // async move {
-    //   into!(group, consumer, keys, ids);
-    //   commands::streams::xreadgroup(self, group, consumer, count, block, noack, keys, ids)
-    //     .await?
-    //     .into_xread_response()
-    // }
-
     async move {
       into!(group, consumer, keys, ids);
       let value = commands::streams::xreadgroup(self, group, consumer, count, block, noack, keys, ids)

--- a/tests/integration/streams/mod.rs
+++ b/tests/integration/streams/mod.rs
@@ -266,7 +266,9 @@ pub async fn should_xread_map_one_key(client: Client, _: Config) -> Result<(), E
   create_fake_group_and_stream(&client, "foo{1}").await?;
   let _ = add_stream_entries(&client, "foo{1}", 3).await?;
 
-  let result: XReadResponse<String, String, String, usize> = client.xread_map(None, None, "foo{1}", "0").await?;
+  let result: XReadResponse<String, String, String, usize> = client.xread_map(None, None, "foo{1}", "0")
+    .await?
+    .expect("Expected Some found None.");
 
   for (idx, (_, record)) in result.get("foo{1}").unwrap().iter().enumerate() {
     let count = record.get("count").expect("Failed to read count");
@@ -415,7 +417,8 @@ pub async fn should_xreadgroup_one_stream(client: Client, _: Config) -> Result<(
 
   let result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", None, None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
 
   assert_eq!(result.len(), 1);
   for (idx, (_, record)) in result.get("foo{1}").unwrap().iter().enumerate() {
@@ -444,7 +447,8 @@ pub async fn should_xreadgroup_multiple_stream(client: Client, _: Config) -> Res
       vec!["foo{1}", "bar{1}"],
       vec![">", ">"],
     )
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
 
   assert_eq!(result.len(), 2);
   for (idx, (_, record)) in result.get("foo{1}").unwrap().iter().enumerate() {
@@ -475,7 +479,8 @@ pub async fn should_xreadgroup_block(client: Client, _: Config) -> Result<(), Er
 
   let mut result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", None, Some(10_000), false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
 
   assert_eq!(result.len(), 1);
   let records = result.remove("foo{1}").unwrap();
@@ -493,7 +498,9 @@ pub async fn should_xack_one_id(client: Client, _: Config) -> Result<(), Error> 
 
   let result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", None, None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   let records = result.get("foo{1}").unwrap();
   let id = records[0].0.clone();
@@ -510,7 +517,9 @@ pub async fn should_xack_multiple_ids(client: Client, _: Config) -> Result<(), E
 
   let result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", None, None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   let records = result.get("foo{1}").unwrap();
   let ids: Vec<String> = records.iter().map(|(id, _)| id.clone()).collect();
@@ -528,7 +537,9 @@ pub async fn should_xclaim_one_id(client: Client, _: Config) -> Result<(), Error
 
   let mut result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", Some(1), None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   assert_eq!(result.get("foo{1}").unwrap().len(), 1);
   let first_read_id = result.get_mut("foo{1}").unwrap().pop().unwrap().0;
@@ -574,7 +585,9 @@ pub async fn should_xclaim_multiple_ids(client: Client, _: Config) -> Result<(),
 
   let mut result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", Some(2), None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   assert_eq!(result.get("foo{1}").unwrap().len(), 2);
   let second_read_id = result.get_mut("foo{1}").unwrap().pop().unwrap().0;
@@ -626,7 +639,9 @@ pub async fn should_xclaim_with_justid(client: Client, _: Config) -> Result<(), 
 
   let mut result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", Some(2), None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   assert_eq!(result.get("foo{1}").unwrap().len(), 2);
   let second_read_id = result.get_mut("foo{1}").unwrap().pop().unwrap().0;
@@ -671,7 +686,9 @@ pub async fn should_xautoclaim_default(client: Client, _: Config) -> Result<(), 
 
   let mut result: XReadResponse<String, String, String, usize> = client
     .xreadgroup_map("group1", "consumer1", Some(2), None, false, "foo{1}", ">")
-    .await?;
+    .await?
+    .expect("Expected Some found None.");
+
   assert_eq!(result.len(), 1);
   assert_eq!(result.get("foo{1}").unwrap().len(), 2);
   let second_read_id = result.get_mut("foo{1}").unwrap().pop().unwrap().0;


### PR DESCRIPTION
Hey All, for xread_map and xreadgroup_map, these methods currently return a Result for situations where a stream has no records and you get an empty or NULL response. 

I think a pragmatic change here would be to check the Value returned from xread and return None in the event that the Value is null instead of returning an Error result. 

It's totally expected/reasonable that a stream will be empty at any point and time and it's important to know when there are no records available for processing vs when an actual error occurs. 