### PR TITLE
fix(router): stop retry_buffer spinning on an unroutable command

### DIFF
--- a/src/router/commands.rs
+++ b/src/router/commands.rs
@@ -81,7 +81,17 @@ async fn create_replica_connection(
     // connection does not exist
     _debug!(inner, "Failed to route command to replica. Deferring reconnection...");
     let err = Error::new(ErrorKind::Routing, "Failed to route command.");
-    command.attempts_remaining += 1;
+    // note: unlike the four branches above, this one deliberately does not restore the attempt that
+    // `write_command` consumed via `decr_check_attempted`. Those hand the command back over the
+    // router's mpsc channel, where `poll_proceed` eventually returns `Pending` once the coop budget
+    // is spent, so an unbounded retry there still lets the runtime make progress. This one hands the
+    // command to `finish_or_retry_command`, which pushes it onto `Router::retry_buffer` -- drained by
+    // the `while let .. pop_front()` loop in `Router::retry_buffer`. Restoring the attempt makes
+    // `attempts_remaining` net-zero across a pass, so the `== 0` arm of `finish_or_retry_command`
+    // never runs and that loop pops the same command forever. Nothing on the path polls a tokio
+    // resource, so its `write_command` await never returns `Pending`, and the loop's `timed_out`
+    // check cannot break the cycle either: setting that flag needs a timer, and a worker spinning
+    // here never returns to the scheduler for one to fire.
     finish_or_retry_command(router, command, &err);
     utils::defer_reconnection(inner, router, None, err, false)?;
     Ok(())


### PR DESCRIPTION
`create_replica_connection`'s final `else` restores the attempt that `write_command` consumed via `decr_check_attempted`, making `attempts_remaining` net-zero across a pass. The `== 0` arm of `finish_or_retry_command` is therefore unreachable, so the command goes back onto `Router::retry_buffer`, and the `while let .. pop_front()` loop that drains it pops the same command forever.

Nothing on that path polls a tokio resource, so the loop's `write_command` await never returns `Pending` and the worker never returns to the scheduler. On a multi-threaded runtime the sibling worker then waits indefinitely in `park_condvar`, having failed to acquire the driver lock, so the time driver stops being polled and every `tokio::time` bound in the process goes inert -- including the one that would set the `timed_out` flag this same loop checks. Both exits from the loop are self-sealed.

The four sibling branches in the same function restore the attempt correctly: they hand the command back over the router's mpsc channel, whose `poll_proceed` returns `Pending` once the coop budget is spent, so an unbounded retry there still lets the runtime make progress. The `cfg(not(replicas))` twin of this branch -- same condition, same error message, same two calls in the same order -- consumes the attempt and terminates.