### PR TITLE
fix(router): bound the replica connection paths independently of ReconnectPolicy

### DIFF
--- a/src/router/commands.rs
+++ b/src/router/commands.rs
@@ -44,7 +44,27 @@ async fn create_replica_connection(
       },
     };
 
-    if let Err(err) = utils::add_replica_with_policy(inner, router, &primary, &replica).await {
+    // note: a single attempt, deliberately, where this used to loop on the reconnection policy.
+    // The router task is the only task that reads the command channel, and it is sitting in this
+    // await, so every queued command waits here too -- including commands routed to a primary that
+    // is perfectly healthy. A replica that accepts TCP but never answers (a frozen container, a
+    // blackholed route) therefore blocks the entire client inside `Replicas::add_connection`, which
+    // hands `transport.setup` a `None` timeout and so waits `internal_command_timeout`.
+    //
+    // Looping made that unbounded rather than merely slow. `ReconnectPolicy` documents
+    // `max_attempts: 0` as unlimited, so `next_reconnection_delay` never returned `Err`, the loop
+    // never exited, and the fallback immediately below -- `ignore_reconnection_errors`, on by
+    // default, whose whole purpose is to serve the command from the primary instead -- was
+    // unreachable. Returning the error is what makes it reachable.
+    //
+    // Nothing is lost by not retrying here. This is the `lazy_connections` path, so the next
+    // command routed to a replica arrives back here and tries again, and every cluster sync calls
+    // `Router::refresh_replica_routing` to rebuild the routing table the retry needs. The global
+    // reconnection counter is left alone on purpose -- spending it here would drain the budget the
+    // primary connection shares, and resetting it on success would mask earlier primary failures.
+    let attempt = router.replicas.add_connection(inner, primary, replica, true).await;
+
+    if let Err(err) = attempt {
       if inner.connection.replica.ignore_reconnection_errors {
         _warn!(
           inner,
@@ -337,7 +357,7 @@ async fn process_replica_reconnect(
 
   #[allow(unused_mut)]
   if replica {
-    let result = utils::sync_replicas_with_policy(inner, router, false).await;
+    let result = utils::sync_replicas_once(inner, router, false).await;
     if let Some(mut tx) = tx {
       let _ = tx.send(result.map(|_| Resp3Frame::Null));
     }
@@ -406,7 +426,7 @@ async fn process_sync_replicas(
   mut tx: OneshotSender<Result<(), Error>>,
   reset: bool,
 ) -> Result<(), Error> {
-  let result = utils::sync_replicas_with_policy(inner, router, reset).await;
+  let result = utils::sync_replicas_once(inner, router, reset).await;
   let _ = tx.send(result);
   Ok(())
 }

--- a/src/router/commands.rs
+++ b/src/router/commands.rs
@@ -81,7 +81,17 @@ async fn create_replica_connection(
     // connection does not exist
     _debug!(inner, "Failed to route command to replica. Deferring reconnection...");
     let err = Error::new(ErrorKind::Routing, "Failed to route command.");
-    command.attempts_remaining += 1;
+    // note: unlike the four branches above, this one deliberately does not restore the attempt that
+    // `write_command` consumed via `decr_check_attempted`. Those hand the command back over the
+    // router's mpsc channel, where `poll_proceed` eventually returns `Pending` once the coop budget
+    // is spent, so an unbounded retry there still lets the runtime make progress. This one hands the
+    // command to `finish_or_retry_command`, which pushes it onto `Router::retry_buffer` -- drained by
+    // the `while let .. pop_front()` loop in `Router::retry_buffer`. Restoring the attempt makes
+    // `attempts_remaining` net-zero across a pass, so the `== 0` arm of `finish_or_retry_command`
+    // never runs and that loop pops the same command forever. Nothing on the path polls a tokio
+    // resource, so its `write_command` await never returns `Pending`, and the loop's `timed_out`
+    // check cannot break the cycle either: setting that flag needs a timer, and a worker spinning
+    // here never returns to the scheduler for one to fire.
     finish_or_retry_command(router, command, &err);
     utils::defer_reconnection(inner, router, None, err, false)?;
     Ok(())

--- a/src/router/utils.rs
+++ b/src/router/utils.rs
@@ -408,35 +408,6 @@ pub async fn reconnect_with_policy(inner: &RefCount<ClientInner>, router: &mut R
   Ok(())
 }
 
-#[cfg(feature = "replicas")]
-pub async fn add_replica_with_policy(
-  inner: &RefCount<ClientInner>,
-  router: &mut Router,
-  primary: &Server,
-  replica: &Server,
-) -> Result<(), Error> {
-  loop {
-    let result = router
-      .replicas
-      .add_connection(inner, primary.clone(), replica.clone(), true)
-      .await;
-
-    if let Err(err) = result {
-      let delay = match next_reconnection_delay(inner) {
-        Ok(dur) => dur,
-        Err(_) => return Err(err),
-      };
-
-      read_and_sleep(inner, router, delay).await?;
-    } else {
-      break;
-    }
-  }
-
-  inner.reset_reconnection_attempts();
-  Ok(())
-}
-
 /// Send `ASKING` to the provided server, reconnecting as needed.
 pub async fn send_asking_with_policy(
   inner: &RefCount<ClientInner>,
@@ -505,41 +476,34 @@ async fn sync_cluster_replicas(inner: &RefCount<ClientInner>, router: &mut Route
   }
 }
 
-/// Repeatedly try to sync the cluster state, reconnecting as needed until the max reconnection attempts is reached.
+/// Try once to sync the replica state.
+///
+/// Deliberately one attempt, where this used to loop on the reconnection policy. The router task is
+/// the only task that reads the command channel, and it is sitting in this await, so retrying here
+/// stalls every queued command -- including commands routed to a healthy primary. A replica that
+/// accepts TCP but never answers makes each attempt cost `internal_command_timeout`, and with
+/// `ReconnectPolicy`'s documented `max_attempts: 0` (unlimited) the loop had no exit at all.
+///
+/// A transient error is now reported to the caller instead of retried. The next cluster sync tries
+/// again, so a replica that is merely slow to come back is still picked up.
 #[cfg(feature = "replicas")]
-pub async fn sync_replicas_with_policy(
+pub async fn sync_replicas_once(
   inner: &RefCount<ClientInner>,
   router: &mut Router,
   reset: bool,
 ) -> Result<(), Error> {
-  let mut delay = Duration::from_millis(0);
+  if let Err(err) = sync_cluster_replicas(inner, router, reset).await {
+    _warn!(inner, "Error syncing replicas: {:?}", err);
 
-  loop {
-    if !delay.is_zero() {
-      _debug!(inner, "Sleeping for {} ms.", delay.as_millis());
-      read_and_sleep(inner, router, delay).await?;
-    }
-
-    if let Err(e) = sync_cluster_replicas(inner, router, reset).await {
-      _warn!(inner, "Error syncing replicas: {:?}", e);
-
-      if e.should_not_reconnect() {
-        break;
-      } else {
-        // return the underlying error on the last attempt
-        delay = match next_reconnection_delay(inner) {
-          Ok(delay) => delay,
-          Err(_) => return Err(e),
-        };
-
-        continue;
-      }
+    // an error the policy would never have retried was swallowed before, and callers depend on that
+    if err.should_not_reconnect() {
+      Ok(())
     } else {
-      break;
+      Err(err)
     }
+  } else {
+    Ok(())
   }
-
-  Ok(())
 }
 
 /// Wait for `inner.connection.cluster_cache_update_delay`.


### PR DESCRIPTION
A replica that accepts TCP but never answers -- a paused container, a
blackholed route -- blocks the whole client, not just replica reads.

The kernel in the peer's netns completes the TCP handshake without the
process, so `connection_timeout` never fires. What hangs is the RESP
handshake in `Replicas::add_connection`, which passes `transport.setup`
a `None` timeout and therefore waits `internal_command_timeout` (10s by
default). That runs inline on the router task, which is the only reader
of the command channel, so while it waits `rx.recv()` is not polled and
every queued command waits with it -- including commands routed to a
primary that is perfectly healthy.

`add_replica_with_policy` and `sync_replicas_with_policy` then made that
unbounded rather than merely slow. Both looped on the reconnection
policy, and `ReconnectPolicy` documents `max_attempts: 0` as unlimited
(`incr_with_max`: `if max != 0 && curr >= max`), so
`next_reconnection_delay` never returned `Err` and neither loop had an
exit. `ReplicaConfig::ignore_reconnection_errors` -- on by default,
whose whole purpose is to serve the command from the primary instead --
sits on the error path of the first of those loops and so was
unreachable for the entire class of failure it was written for.

Config cannot substitute for this. A finite `max_attempts` does arm the
replica escape hatch, but the policy is one per client: exhausting it on
the primary returns `Err` from `reconnect_with_policy`, which breaks the
`read_or_write` loop and ends the router task, killing the client for
good. `lazy_connections = false` only moves the block from one of these
loops to the other.

So both paths now make a single attempt and report failure:

- the command path attempts `add_connection` inline, which lets
  `ignore_reconnection_errors` do its documented job and fall back to
  the primary. `add_replica_with_policy` had no other caller and is
  removed.
- `sync_replicas_with_policy` becomes `sync_replicas_once`. Errors the
  policy would never have retried are still swallowed, as before; a
  transient error is now returned instead of retried forever. Both
  callers already deliver it over their response channel and return
  `Ok(())`, so the router task is unaffected.

Neither path touches the global reconnection counter any more. Spending
it drained a budget shared with the primary connection, and the reset on
success masked earlier primary failures.

Behaviour change worth noting: `Client::sync_replicas()` can now return
a transient error where it previously blocked until the sync succeeded.
Replica connections are still retried -- by the next command routed to a
replica under `lazy_connections`, and by the routing refresh on every
cluster sync.